### PR TITLE
Update to 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ You can install this python module from sources if you have all the
 [dependencies] of the C++ chemfiles library installed on your computer.
 
 ```bash
-# To get the latest developement version:
+# To get the latest development version:
 git clone https://github.com/chemfiles/chemfiles.py
 cd chemfiles.py
 git submodule update --init
-# Install developement dependencies
+# Install development dependencies
 pip install -r dev-requirements.txt
+# Install chemfiles
 pip install .
 # Optionally run the test suite
 tox

--- a/chemfiles/__init__.py
+++ b/chemfiles/__init__.py
@@ -11,4 +11,4 @@ from .trajectory import Trajectory
 from .selection import Selection
 from .property import Property
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/chemfiles/__init__.py
+++ b/chemfiles/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from .misc import ChemfilesError, set_warnings_callback, add_configuration
 from .atom import Atom
 from .residue import Residue
-from .topology import Topology
+from .topology import Topology, BondOrder
 from .cell import UnitCell, CellShape
 from .frame import Frame
 from .trajectory import Trajectory

--- a/chemfiles/__init__.py
+++ b/chemfiles/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from .utils import ChemfilesError, set_warnings_callback, add_configuration
+from .misc import ChemfilesError, set_warnings_callback, add_configuration
 from .atom import Atom
 from .residue import Residue
 from .topology import Topology

--- a/chemfiles/atom.py
+++ b/chemfiles/atom.py
@@ -7,7 +7,7 @@ from .property import Property
 
 
 class Atom(CxxPointer):
-    '''
+    """
     An :py:class:`Atom` is a particle in the current :py:class:`Frame`. It
     stores the following atomic properties:
 
@@ -19,121 +19,113 @@ class Atom(CxxPointer):
     The atom name is usually an unique identifier (``"H1"``, ``"C_a"``) while
     the atom type will be shared between all particles of the same type:
     ``"H"``, ``"Ow"``, ``"CH3"``.
-    '''
+    """
 
     def __init__(self, name, type=None):
-        '''
+        """
         Create a new :py:class:`Atom` from a ``name``, and set the atom type
         to ``name``.
-        '''
+        """
         super(Atom, self).__init__(self.ffi.chfl_atom(name.encode("utf8")))
         if type:
             self.set_type(type)
-
-    def __del__(self):
-        if hasattr(self, 'ptr'):
-            self.ffi.chfl_atom_free(self)
 
     def __copy__(self):
         return Atom.from_ptr(self.ffi.chfl_atom_copy(self))
 
     def mass(self):
-        '''Get this :py:class:`Atom` mass, in atomic mass units.'''
+        """Get this :py:class:`Atom` mass, in atomic mass units."""
         mass = c_double()
         self.ffi.chfl_atom_mass(self, mass)
         return mass.value
 
     def set_mass(self, mass):
-        '''Set this :py:class:`Atom` mass, in atomic mass units.'''
+        """Set this :py:class:`Atom` mass, in atomic mass units."""
         self.ffi.chfl_atom_set_mass(self, c_double(mass))
 
     def charge(self):
-        '''
+        """
         Get this :py:class:`Atom` charge, in number of the electron charge *e*.
-        '''
+        """
         charge = c_double()
         self.ffi.chfl_atom_charge(self, charge)
         return charge.value
 
     def set_charge(self, charge):
-        '''
+        """
         Set this :py:class:`Atom` charge, in number of the electron charge *e*.
-        '''
+        """
         self.ffi.chfl_atom_set_charge(self, c_double(charge))
 
     def name(self):
-        '''Get this :py:class:`Atom` name.'''
+        """Get this :py:class:`Atom` name."""
         return _call_with_growing_buffer(
-            lambda buffer, size: self.ffi.chfl_atom_name(self, buffer, size),
-            initial=32,
+            lambda buffer, size: self.ffi.chfl_atom_name(self, buffer, size), initial=32
         )
 
     def set_name(self, name):
-        '''Set this :py:class:`Atom` name to ``name``.'''
+        """Set this :py:class:`Atom` name to ``name``."""
         self.ffi.chfl_atom_set_name(self, name.encode("utf8"))
 
     def type(self):
-        '''Get this :py:class:`Atom` type.'''
+        """Get this :py:class:`Atom` type."""
         return _call_with_growing_buffer(
-            lambda buffer, size: self.ffi.chfl_atom_type(self, buffer, size),
-            initial=32,
+            lambda buffer, size: self.ffi.chfl_atom_type(self, buffer, size), initial=32
         )
 
     def set_type(self, type):
-        '''Set this :py:class:`Atom` type to ``type``.'''
+        """Set this :py:class:`Atom` type to ``type``."""
         self.ffi.chfl_atom_set_type(self, type.encode("utf8"))
 
     def full_name(self):
-        '''
+        """
         Try to get the full name of this :py:class:`Atom` from its type. For
         example, the full name of "He" is "Helium". If the name can not be
         found, returns the empty string.
-        '''
+        """
         return _call_with_growing_buffer(
             lambda buff, size: self.ffi.chfl_atom_full_name(self, buff, size),
             initial=64,
         )
 
     def vdw_radius(self):
-        '''
+        """
         Try to get the Van der Waals radius of this :py:class:`Atom` from its
         type. If the radius can not be found, returns 0.
-        '''
+        """
         radius = c_double()
         self.ffi.chfl_atom_vdw_radius(self, radius)
         return radius.value
 
     def covalent_radius(self):
-        '''
+        """
         Try to get the covalent radius of this :py:class:`Atom` from its type.
         If the radius can not be found, returns 0.
-        '''
+        """
         radius = c_double()
         self.ffi.chfl_atom_covalent_radius(self, radius)
         return radius.value
 
     def atomic_number(self):
-        '''
+        """
         Try to get the atomic number of this :py:class:`Atom` from its type. If
         the atomic number can not be found, returns 0.
-        '''
+        """
         number = c_uint64()
         self.ffi.chfl_atom_atomic_number(self, number)
         return number.value
 
     def set(self, name, value):
-        '''
+        """
         Set a property of this atom, with the given ``name`` and ``value``.
         The new value overwrite any pre-existing property with the same name.
-        '''
-        self.ffi.chfl_atom_set_property(
-            self, name.encode("utf8"), Property(value)
-        )
+        """
+        self.ffi.chfl_atom_set_property(self, name.encode("utf8"), Property(value))
 
     def get(self, name):
-        '''
+        """
         Get a property of this atom with the given ``name``, or raise an error
         if the property does not exists.
-        '''
+        """
         ptr = self.ffi.chfl_atom_get_property(self, name.encode("utf8"))
         return Property.from_ptr(ptr).get()

--- a/chemfiles/atom.py
+++ b/chemfiles/atom.py
@@ -23,10 +23,12 @@ class Atom(CxxPointer):
 
     def __init__(self, name, type=None):
         """
-        Create a new :py:class:`Atom` from a ``name``, and set the atom type
-        to ``name``.
+        Create a new :py:class:`Atom` with the given ``name``. If ``type`` is
+        present, use it as the atom type. Else the atom name is used as atom
+        type.
         """
-        super(Atom, self).__init__(self.ffi.chfl_atom(name.encode("utf8")))
+        ptr = self.ffi.chfl_atom(name.encode("utf8"))
+        super(Atom, self).__init__(ptr, is_const=False)
         if type:
             self.set_type(type)
 

--- a/chemfiles/atom.py
+++ b/chemfiles/atom.py
@@ -1,6 +1,6 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
-from ctypes import c_double, c_uint64
+from ctypes import c_double, c_uint64, c_char_p
 
 from ._utils import CxxPointer, _call_with_growing_buffer, string_type
 from .property import Property
@@ -155,3 +155,17 @@ class Atom(CxxPointer):
                 "Invalid type {} for an atomic property name".format(type(name))
             )
         self.ffi.chfl_atom_set_property(self, name.encode("utf8"), Property(value))
+
+    def properties_count(self):
+        """Get the number of properties in this atom."""
+        count = c_uint64()
+        self.ffi.chfl_atom_properties_count(self, count)
+        return count.value
+
+    def list_properties(self):
+        """Get the name of all properties in this atom."""
+        count = self.properties_count()
+        StringArray = c_char_p * count
+        names = StringArray()
+        self.ffi.chfl_atom_list_properties(self, names, count)
+        return list(map(lambda n: n.decode("utf8"), names))

--- a/chemfiles/atom.py
+++ b/chemfiles/atom.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from ctypes import c_double, c_uint64, c_char_p
 
 from ._utils import CxxPointer, _call_with_growing_buffer, string_type
+from .misc import ChemfilesError
 from .property import Property
 
 

--- a/chemfiles/atom.py
+++ b/chemfiles/atom.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from ctypes import c_double, c_uint64
 
-from .utils import CxxPointer, _call_with_growing_buffer
+from ._utils import CxxPointer, _call_with_growing_buffer, string_type
 from .property import Property
 
 
@@ -30,21 +30,24 @@ class Atom(CxxPointer):
         ptr = self.ffi.chfl_atom(name.encode("utf8"))
         super(Atom, self).__init__(ptr, is_const=False)
         if type:
-            self.set_type(type)
+            self.type = type
 
     def __copy__(self):
         return Atom.from_ptr(self.ffi.chfl_atom_copy(self))
 
+    @property
     def mass(self):
         """Get this :py:class:`Atom` mass, in atomic mass units."""
         mass = c_double()
         self.ffi.chfl_atom_mass(self, mass)
         return mass.value
 
-    def set_mass(self, mass):
+    @mass.setter
+    def mass(self, mass):
         """Set this :py:class:`Atom` mass, in atomic mass units."""
         self.ffi.chfl_atom_set_mass(self, c_double(mass))
 
+    @property
     def charge(self):
         """
         Get this :py:class:`Atom` charge, in number of the electron charge *e*.
@@ -53,32 +56,38 @@ class Atom(CxxPointer):
         self.ffi.chfl_atom_charge(self, charge)
         return charge.value
 
-    def set_charge(self, charge):
+    @charge.setter
+    def charge(self, charge):
         """
         Set this :py:class:`Atom` charge, in number of the electron charge *e*.
         """
         self.ffi.chfl_atom_set_charge(self, c_double(charge))
 
+    @property
     def name(self):
         """Get this :py:class:`Atom` name."""
         return _call_with_growing_buffer(
             lambda buffer, size: self.ffi.chfl_atom_name(self, buffer, size), initial=32
         )
 
-    def set_name(self, name):
+    @name.setter
+    def name(self, name):
         """Set this :py:class:`Atom` name to ``name``."""
         self.ffi.chfl_atom_set_name(self, name.encode("utf8"))
 
+    @property
     def type(self):
         """Get this :py:class:`Atom` type."""
         return _call_with_growing_buffer(
             lambda buffer, size: self.ffi.chfl_atom_type(self, buffer, size), initial=32
         )
 
-    def set_type(self, type):
+    @type.setter
+    def type(self, type):
         """Set this :py:class:`Atom` type to ``type``."""
         self.ffi.chfl_atom_set_type(self, type.encode("utf8"))
 
+    @property
     def full_name(self):
         """
         Try to get the full name of this :py:class:`Atom` from its type. For
@@ -90,6 +99,7 @@ class Atom(CxxPointer):
             initial=64,
         )
 
+    @property
     def vdw_radius(self):
         """
         Try to get the Van der Waals radius of this :py:class:`Atom` from its
@@ -99,6 +109,7 @@ class Atom(CxxPointer):
         self.ffi.chfl_atom_vdw_radius(self, radius)
         return radius.value
 
+    @property
     def covalent_radius(self):
         """
         Try to get the covalent radius of this :py:class:`Atom` from its type.
@@ -108,6 +119,7 @@ class Atom(CxxPointer):
         self.ffi.chfl_atom_covalent_radius(self, radius)
         return radius.value
 
+    @property
     def atomic_number(self):
         """
         Try to get the atomic number of this :py:class:`Atom` from its type. If
@@ -117,17 +129,29 @@ class Atom(CxxPointer):
         self.ffi.chfl_atom_atomic_number(self, number)
         return number.value
 
-    def set(self, name, value):
-        """
-        Set a property of this atom, with the given ``name`` and ``value``.
-        The new value overwrite any pre-existing property with the same name.
-        """
-        self.ffi.chfl_atom_set_property(self, name.encode("utf8"), Property(value))
+    def __iter__(self):
+        # Disable automatic iteration from __getitem__
+        raise TypeError("can not iterate over an atom")
 
-    def get(self, name):
+    def __getitem__(self, name):
         """
         Get a property of this atom with the given ``name``, or raise an error
         if the property does not exists.
         """
+        if not isinstance(name, string_type):
+            raise ChemfilesError(
+                "Invalid type {} for an atomic property name".format(type(name))
+            )
         ptr = self.ffi.chfl_atom_get_property(self, name.encode("utf8"))
         return Property.from_ptr(ptr).get()
+
+    def __setitem__(self, name, value):
+        """
+        Set a property of this atom, with the given ``name`` and ``value``.
+        The new value overwrite any pre-existing property with the same name.
+        """
+        if not isinstance(name, string_type):
+            raise ChemfilesError(
+                "Invalid type {} for an atomic property name".format(type(name))
+            )
+        self.ffi.chfl_atom_set_property(self, name.encode("utf8"), Property(value))

--- a/chemfiles/cell.py
+++ b/chemfiles/cell.py
@@ -8,13 +8,13 @@ from .ffi import chfl_cellshape, chfl_vector3d
 
 
 class CellShape(IntEnum):
-    '''
+    """
     Available cell shapes in Chemfiles:
 
     - ``CellType.Orthorhombic``: for cells where the three angles are 90°;
     - ``CellType.Triclinic``: for cells where the three angles may not be 90°;
     - ``CellType.Infinite``: for cells without periodic boundary conditions;
-    '''
+    """
 
     Orthorhombic = chfl_cellshape.CHFL_CELL_ORTHORHOMBIC
     Triclinic = chfl_cellshape.CHFL_CELL_TRICLINIC
@@ -22,7 +22,7 @@ class CellShape(IntEnum):
 
 
 class UnitCell(CxxPointer):
-    '''
+    """
     An :py:class:`UnitCell` represent the box containing the atoms, and its
     periodicity.
 
@@ -41,16 +41,16 @@ class UnitCell(CxxPointer):
         | a_x   b_x   c_x |
         |  0    b_y   c_y |
         |  0     0    c_z |
-    '''
+    """
 
     def __init__(self, a, b, c, alpha=90.0, beta=90.0, gamma=90.0):
-        '''
+        """
         Create a new :py:class:`UnitCell` with cell lenghts of ``a``, ``b`` and
         ``c``, and cell angles ``alpha``, ``beta`` and ``gamma``.
 
         If alpha, beta and gamma are equal to 90.0, the new unit cell shape is
         ``CellShape.Orthorhombic``. Else it is ``CellShape.Infinite``.
-        '''
+        """
         lenghts = chfl_vector3d(a, b, c)
         angles = chfl_vector3d(alpha, beta, gamma)
         if alpha == 90.0 and beta == 90.0 and gamma == 90.0:
@@ -59,44 +59,38 @@ class UnitCell(CxxPointer):
             ptr = self.ffi.chfl_cell_triclinic(lenghts, angles)
         super(UnitCell, self).__init__(ptr)
 
-    def __del__(self):
-        if hasattr(self, 'ptr'):
-            self.ffi.chfl_cell_free(self)
-
     def __copy__(self):
         return UnitCell.from_ptr(self.ffi.chfl_cell_copy(self))
 
     def lengths(self):
-        '''Get the three lenghts of this :py:class:`UnitCell`, in Angstroms.'''
+        """Get the three lenghts of this :py:class:`UnitCell`, in Angstroms."""
         lengths = chfl_vector3d(0, 0, 0)
         self.ffi.chfl_cell_lengths(self, lengths)
         return lengths[0], lengths[1], lengths[2]
 
     def set_lengths(self, a, b, c):
-        '''
+        """
         Set the three lenghts of this :py:class:`UnitCell` to ``a``, ``b`` and
         ``c``. These values should be in Angstroms.
-        '''
+        """
         self.ffi.chfl_cell_set_lengths(self, chfl_vector3d(a, b, c))
 
     def angles(self):
-        '''Get the three angles of this :py:class:`UnitCell`, in degrees.'''
+        """Get the three angles of this :py:class:`UnitCell`, in degrees."""
         angles = chfl_vector3d(0, 0, 0)
         self.ffi.chfl_cell_angles(self, angles)
         return angles[0], angles[1], angles[2]
 
     def set_angles(self, alpha, beta, gamma):
-        '''
+        """
         Set the three angles of this :py:class:`UnitCell` to ``alpha``,
         ``beta`` and ``gamma``. These values should be in degrees. Setting
         angles is only possible for ``CellShape.Triclinic`` cells.
-        '''
-        self.ffi.chfl_cell_set_angles(
-            self, chfl_vector3d(alpha, beta, gamma)
-        )
+        """
+        self.ffi.chfl_cell_set_angles(self, chfl_vector3d(alpha, beta, gamma))
 
     def matrix(self):
-        '''
+        """
         Get this :py:class:`UnitCell` matricial representation.
 
         The matricial representation is obtained by aligning the a vector along
@@ -108,7 +102,7 @@ class UnitCell(CxxPointer):
             | a_x   b_x   c_x |
             |  0    b_y   c_y |
             |  0     0    c_z |
-        '''
+        """
         m = ARRAY(chfl_vector3d, 3)()
         self.ffi.chfl_cell_matrix(self, m)
         return [
@@ -118,26 +112,26 @@ class UnitCell(CxxPointer):
         ]
 
     def shape(self):
-        '''Get the shape of this :py:class:`UnitCell`.'''
+        """Get the shape of this :py:class:`UnitCell`."""
         shape = chfl_cellshape()
         self.ffi.chfl_cell_shape(self, shape)
         return CellShape(shape.value)
 
     def set_shape(self, shape):
-        '''Set the shape of this :py:class:`UnitCell` to ``shape``.'''
+        """Set the shape of this :py:class:`UnitCell` to ``shape``."""
         self.ffi.chfl_cell_set_shape(self, chfl_cellshape(shape))
 
     def volume(self):
-        '''Get the volume of this :py:class:`UnitCell`.'''
+        """Get the volume of this :py:class:`UnitCell`."""
         volume = c_double()
         self.ffi.chfl_cell_volume(self, volume)
         return volume.value
 
     def wrap(self, vector):
-        '''
+        """
         Wrap a ``vector`` in this :py:class:`UnitCell`, and return the wrapped
         vector.
-        '''
+        """
         vector = chfl_vector3d(vector[0], vector[1], vector[2])
         self.ffi.chfl_cell_wrap(self, vector)
         return (vector[0], vector[1], vector[2])

--- a/chemfiles/cell.py
+++ b/chemfiles/cell.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from ctypes import c_double, ARRAY
 from enum import IntEnum
 
-from .utils import CxxPointer
+from ._utils import CxxPointer
 from .ffi import chfl_cellshape, chfl_vector3d
 
 
@@ -62,33 +62,40 @@ class UnitCell(CxxPointer):
     def __copy__(self):
         return UnitCell.from_ptr(self.ffi.chfl_cell_copy(self))
 
+    @property
     def lengths(self):
         """Get the three lenghts of this :py:class:`UnitCell`, in Angstroms."""
         lengths = chfl_vector3d(0, 0, 0)
         self.ffi.chfl_cell_lengths(self, lengths)
         return lengths[0], lengths[1], lengths[2]
 
-    def set_lengths(self, a, b, c):
+    @lengths.setter
+    def lengths(self, lengths):
         """
-        Set the three lenghts of this :py:class:`UnitCell` to ``a``, ``b`` and
-        ``c``. These values should be in Angstroms.
+        Set the three lenghts of this :py:class:`UnitCell` to ``lengths``. The
+        values should be in Angstroms.
         """
+        a, b, c = lengths
         self.ffi.chfl_cell_set_lengths(self, chfl_vector3d(a, b, c))
 
+    @property
     def angles(self):
         """Get the three angles of this :py:class:`UnitCell`, in degrees."""
         angles = chfl_vector3d(0, 0, 0)
         self.ffi.chfl_cell_angles(self, angles)
         return angles[0], angles[1], angles[2]
 
-    def set_angles(self, alpha, beta, gamma):
+    @angles.setter
+    def angles(self, angles):
         """
         Set the three angles of this :py:class:`UnitCell` to ``alpha``,
         ``beta`` and ``gamma``. These values should be in degrees. Setting
         angles is only possible for ``CellShape.Triclinic`` cells.
         """
+        alpha, beta, gamma = angles
         self.ffi.chfl_cell_set_angles(self, chfl_vector3d(alpha, beta, gamma))
 
+    @property
     def matrix(self):
         """
         Get this :py:class:`UnitCell` matricial representation.
@@ -111,16 +118,19 @@ class UnitCell(CxxPointer):
             (m[2][0], m[2][1], m[2][2]),
         ]
 
+    @property
     def shape(self):
         """Get the shape of this :py:class:`UnitCell`."""
         shape = chfl_cellshape()
         self.ffi.chfl_cell_shape(self, shape)
         return CellShape(shape.value)
 
-    def set_shape(self, shape):
+    @shape.setter
+    def shape(self, shape):
         """Set the shape of this :py:class:`UnitCell` to ``shape``."""
         self.ffi.chfl_cell_set_shape(self, chfl_cellshape(shape))
 
+    @property
     def volume(self):
         """Get the volume of this :py:class:`UnitCell`."""
         volume = c_double()

--- a/chemfiles/cell.py
+++ b/chemfiles/cell.py
@@ -57,7 +57,7 @@ class UnitCell(CxxPointer):
             ptr = self.ffi.chfl_cell(lenghts)
         else:
             ptr = self.ffi.chfl_cell_triclinic(lenghts, angles)
-        super(UnitCell, self).__init__(ptr)
+        super(UnitCell, self).__init__(ptr, is_const=False)
 
     def __copy__(self):
         return UnitCell.from_ptr(self.ffi.chfl_cell_copy(self))

--- a/chemfiles/clib.py
+++ b/chemfiles/clib.py
@@ -20,15 +20,19 @@ class FindChemfilesLibrary(object):
 
             from .ffi import set_interface
             from .ffi import CHFL_FRAME, CHFL_ATOM, chfl_vector3d
+
             set_interface(self._cache)
             # We update the arguments here, as ctypes can not pass a NULL value
             # as the last parameter
             self._cache.chfl_frame_add_atom.argtypes = [
-                POINTER(CHFL_FRAME), POINTER(CHFL_ATOM),
-                chfl_vector3d, POINTER(c_double)
+                POINTER(CHFL_FRAME),
+                POINTER(CHFL_ATOM),
+                chfl_vector3d,
+                POINTER(c_double),
             ]
 
             from .utils import _set_default_warning_callback
+
             _set_default_warning_callback()
         return self._cache
 
@@ -44,7 +48,7 @@ def _lib_path():
     elif sys.platform.startswith("win"):
         candidates = [
             os.path.join(root, "bin", "libchemfiles.dll"),  # MinGW
-            os.path.join(root, "bin", "chemfiles.dll"),     # MSVC
+            os.path.join(root, "bin", "chemfiles.dll"),  # MSVC
         ]
         for path in candidates:
             if os.path.isfile(path):
@@ -63,7 +67,7 @@ def _check_dll(path):
     IMAGE_FILE_MACHINE_AMD64 = 34404
 
     machine = None
-    with open(path, 'rb') as fd:
+    with open(path, "rb") as fd:
         header = fd.read(2).decode(encoding="utf-8", errors="strict")
         if header != "MZ":
             raise ImportError(path + " is not a DLL")

--- a/chemfiles/clib.py
+++ b/chemfiles/clib.py
@@ -31,7 +31,7 @@ class FindChemfilesLibrary(object):
                 POINTER(c_double),
             ]
 
-            from .utils import _set_default_warning_callback
+            from .misc import _set_default_warning_callback
 
             _set_default_warning_callback()
         return self._cache

--- a/chemfiles/ffi.py
+++ b/chemfiles/ffi.py
@@ -17,7 +17,7 @@ import numpy as np
 from ctypes import c_int, c_uint64, c_double, c_char, c_char_p, c_void_p, c_bool
 from ctypes import CFUNCTYPE, ARRAY, POINTER, Structure
 
-from .utils import _check_return_code
+from ._utils import _check_return_code
 
 
 class chfl_status(c_int):

--- a/chemfiles/ffi.py
+++ b/chemfiles/ffi.py
@@ -1,10 +1,6 @@
 # -* coding: utf-8 -*
-# Chemfiles, an efficient IO library for chemistry file formats
-# Copyright (C) 2015 Guillaume Fraux
-#
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/
+# Chemfiles, a modern library for chemistry file reading and writing
+# Copyright (C) Guillaume Fraux and contributors -- BSD license
 #
 # =========================================================================== #
 # !!!! AUTO-GENERATED FILE !!!! Do not edit. See the bindgen repository for
@@ -18,7 +14,7 @@ Foreign function interface declaration for the Python interface to chemfiles
 '''
 from numpy.ctypeslib import ndpointer
 import numpy as np
-from ctypes import c_int, c_uint64, c_int64, c_double, c_char, c_char_p, c_bool
+from ctypes import c_int, c_uint64, c_double, c_char, c_char_p, c_void_p, c_bool
 from ctypes import CFUNCTYPE, ARRAY, POINTER, Structure
 
 from .utils import _check_return_code
@@ -35,6 +31,17 @@ class chfl_status(c_int):
     CHFL_PROPERTY_ERROR = 7
     CHFL_GENERIC_ERROR = 254
     CHFL_CXX_ERROR = 255
+
+
+class chfl_bond_order(c_int):
+    CHFL_BOND_UNKNOWN = 0
+    CHFL_BOND_SINGLE = 1
+    CHFL_BOND_DOUBLE = 2
+    CHFL_BOND_TRIPLE = 3
+    CHFL_BOND_QUADRUPLE = 4
+    CHFL_BOND_QINTUPLET = 5
+    CHFL_BOND_AMIDE = 254
+    CHFL_BOND_AROMATIC = 255
 
 
 class chfl_property_kind(c_int):
@@ -107,587 +114,616 @@ def set_interface(c_lib):
 
     from chemfiles import Property
 
-    # Function "chfl_version", at types.h:145
+    # Manually defined functions
+    c_lib.chfl_free.argtypes = [c_void_p]
+    c_lib.chfl_trajectory_close.argtypes = [Trajectory]
+    # End of manually defined functions
+
+    # Function "chfl_version", at types.h:145:14
     c_lib.chfl_version.argtypes = []
     c_lib.chfl_version.restype = c_char_p
 
-    # Function "chfl_last_error", at misc.h:19
+    # Function "chfl_last_error", at misc.h:19:14
     c_lib.chfl_last_error.argtypes = []
     c_lib.chfl_last_error.restype = c_char_p
 
-    # Function "chfl_clear_errors", at misc.h:29
+    # Function "chfl_clear_errors", at misc.h:29:14
     c_lib.chfl_clear_errors.argtypes = []
     c_lib.chfl_clear_errors.restype = chfl_status
     c_lib.chfl_clear_errors.errcheck = _check_return_code
 
-    # Function "chfl_set_warning_callback", at misc.h:38
+    # Function "chfl_set_warning_callback", at misc.h:38:14
     c_lib.chfl_set_warning_callback.argtypes = [chfl_warning_callback]
     c_lib.chfl_set_warning_callback.restype = chfl_status
     c_lib.chfl_set_warning_callback.errcheck = _check_return_code
 
-    # Function "chfl_add_configuration", at misc.h:53
+    # Function "chfl_add_configuration", at misc.h:54:14
     c_lib.chfl_add_configuration.argtypes = [c_char_p]
     c_lib.chfl_add_configuration.restype = chfl_status
     c_lib.chfl_add_configuration.errcheck = _check_return_code
 
-    # Function "chfl_property_bool", at property.h:32
+    # Function "chfl_property_bool", at property.h:32:17
     c_lib.chfl_property_bool.argtypes = [c_bool]
     c_lib.chfl_property_bool.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_property_double", at property.h:42
+    # Function "chfl_property_double", at property.h:42:17
     c_lib.chfl_property_double.argtypes = [c_double]
     c_lib.chfl_property_double.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_property_string", at property.h:52
+    # Function "chfl_property_string", at property.h:52:17
     c_lib.chfl_property_string.argtypes = [c_char_p]
     c_lib.chfl_property_string.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_property_vector3d", at property.h:62
+    # Function "chfl_property_vector3d", at property.h:62:17
     c_lib.chfl_property_vector3d.argtypes = [chfl_vector3d]
     c_lib.chfl_property_vector3d.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_property_get_kind", at property.h:69
+    # Function "chfl_property_get_kind", at property.h:69:14
     c_lib.chfl_property_get_kind.argtypes = [Property, POINTER(chfl_property_kind)]
     c_lib.chfl_property_get_kind.restype = chfl_status
     c_lib.chfl_property_get_kind.errcheck = _check_return_code
 
-    # Function "chfl_property_get_bool", at property.h:82
+    # Function "chfl_property_get_bool", at property.h:82:14
     c_lib.chfl_property_get_bool.argtypes = [Property, POINTER(c_bool)]
     c_lib.chfl_property_get_bool.restype = chfl_status
     c_lib.chfl_property_get_bool.errcheck = _check_return_code
 
-    # Function "chfl_property_get_double", at property.h:95
+    # Function "chfl_property_get_double", at property.h:95:14
     c_lib.chfl_property_get_double.argtypes = [Property, POINTER(c_double)]
     c_lib.chfl_property_get_double.restype = chfl_status
     c_lib.chfl_property_get_double.errcheck = _check_return_code
 
-    # Function "chfl_property_get_string", at property.h:110
+    # Function "chfl_property_get_string", at property.h:110:14
     c_lib.chfl_property_get_string.argtypes = [Property, c_char_p, c_uint64]
     c_lib.chfl_property_get_string.restype = chfl_status
     c_lib.chfl_property_get_string.errcheck = _check_return_code
 
-    # Function "chfl_property_get_vector3d", at property.h:123
+    # Function "chfl_property_get_vector3d", at property.h:123:14
     c_lib.chfl_property_get_vector3d.argtypes = [Property, chfl_vector3d]
     c_lib.chfl_property_get_vector3d.restype = chfl_status
     c_lib.chfl_property_get_vector3d.errcheck = _check_return_code
 
-    # Function "chfl_property_free", at property.h:131
-    c_lib.chfl_property_free.argtypes = [Property]
-    c_lib.chfl_property_free.restype = chfl_status
-    c_lib.chfl_property_free.errcheck = _check_return_code
-
-    # Function "chfl_atom", at atom.h:20
+    # Function "chfl_atom", at atom.h:20:13
     c_lib.chfl_atom.argtypes = [c_char_p]
     c_lib.chfl_atom.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_copy", at atom.h:30
+    # Function "chfl_atom_copy", at atom.h:30:13
     c_lib.chfl_atom_copy.argtypes = [Atom]
     c_lib.chfl_atom_copy.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_from_frame", at atom.h:42
+    # Function "chfl_atom_from_frame", at atom.h:54:13
     c_lib.chfl_atom_from_frame.argtypes = [Frame, c_uint64]
     c_lib.chfl_atom_from_frame.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_from_topology", at atom.h:53
+    # Function "chfl_atom_from_topology", at atom.h:77:13
     c_lib.chfl_atom_from_topology.argtypes = [Topology, c_uint64]
     c_lib.chfl_atom_from_topology.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_mass", at atom.h:64
+    # Function "chfl_atom_mass", at atom.h:88:14
     c_lib.chfl_atom_mass.argtypes = [Atom, POINTER(c_double)]
     c_lib.chfl_atom_mass.restype = chfl_status
     c_lib.chfl_atom_mass.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_mass", at atom.h:73
+    # Function "chfl_atom_set_mass", at atom.h:97:14
     c_lib.chfl_atom_set_mass.argtypes = [Atom, c_double]
     c_lib.chfl_atom_set_mass.restype = chfl_status
     c_lib.chfl_atom_set_mass.errcheck = _check_return_code
 
-    # Function "chfl_atom_charge", at atom.h:82
+    # Function "chfl_atom_charge", at atom.h:106:14
     c_lib.chfl_atom_charge.argtypes = [Atom, POINTER(c_double)]
     c_lib.chfl_atom_charge.restype = chfl_status
     c_lib.chfl_atom_charge.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_charge", at atom.h:91
+    # Function "chfl_atom_set_charge", at atom.h:115:14
     c_lib.chfl_atom_set_charge.argtypes = [Atom, c_double]
     c_lib.chfl_atom_set_charge.restype = chfl_status
     c_lib.chfl_atom_set_charge.errcheck = _check_return_code
 
-    # Function "chfl_atom_type", at atom.h:101
+    # Function "chfl_atom_type", at atom.h:125:14
     c_lib.chfl_atom_type.argtypes = [Atom, c_char_p, c_uint64]
     c_lib.chfl_atom_type.restype = chfl_status
     c_lib.chfl_atom_type.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_type", at atom.h:112
+    # Function "chfl_atom_set_type", at atom.h:136:14
     c_lib.chfl_atom_set_type.argtypes = [Atom, c_char_p]
     c_lib.chfl_atom_set_type.restype = chfl_status
     c_lib.chfl_atom_set_type.errcheck = _check_return_code
 
-    # Function "chfl_atom_name", at atom.h:122
+    # Function "chfl_atom_name", at atom.h:146:14
     c_lib.chfl_atom_name.argtypes = [Atom, c_char_p, c_uint64]
     c_lib.chfl_atom_name.restype = chfl_status
     c_lib.chfl_atom_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_name", at atom.h:133
+    # Function "chfl_atom_set_name", at atom.h:157:14
     c_lib.chfl_atom_set_name.argtypes = [Atom, c_char_p]
     c_lib.chfl_atom_set_name.restype = chfl_status
     c_lib.chfl_atom_set_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_full_name", at atom.h:143
+    # Function "chfl_atom_full_name", at atom.h:167:14
     c_lib.chfl_atom_full_name.argtypes = [Atom, c_char_p, c_uint64]
     c_lib.chfl_atom_full_name.restype = chfl_status
     c_lib.chfl_atom_full_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_vdw_radius", at atom.h:155
+    # Function "chfl_atom_vdw_radius", at atom.h:179:14
     c_lib.chfl_atom_vdw_radius.argtypes = [Atom, POINTER(c_double)]
     c_lib.chfl_atom_vdw_radius.restype = chfl_status
     c_lib.chfl_atom_vdw_radius.errcheck = _check_return_code
 
-    # Function "chfl_atom_covalent_radius", at atom.h:165
+    # Function "chfl_atom_covalent_radius", at atom.h:189:14
     c_lib.chfl_atom_covalent_radius.argtypes = [Atom, POINTER(c_double)]
     c_lib.chfl_atom_covalent_radius.restype = chfl_status
     c_lib.chfl_atom_covalent_radius.errcheck = _check_return_code
 
-    # Function "chfl_atom_atomic_number", at atom.h:175
+    # Function "chfl_atom_atomic_number", at atom.h:199:14
     c_lib.chfl_atom_atomic_number.argtypes = [Atom, POINTER(c_uint64)]
     c_lib.chfl_atom_atomic_number.restype = chfl_status
     c_lib.chfl_atom_atomic_number.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_property", at atom.h:185
+    # Function "chfl_atom_properties_count", at atom.h:206:14
+    c_lib.chfl_atom_properties_count.argtypes = [Atom, POINTER(c_uint64)]
+    c_lib.chfl_atom_properties_count.restype = chfl_status
+    c_lib.chfl_atom_properties_count.errcheck = _check_return_code
+
+    # Function "chfl_atom_list_properties", at atom.h:222:14
+    c_lib.chfl_atom_list_properties.argtypes = [Atom, ndpointer(c_char, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    c_lib.chfl_atom_list_properties.restype = chfl_status
+    c_lib.chfl_atom_list_properties.errcheck = _check_return_code
+
+    # Function "chfl_atom_set_property", at atom.h:234:14
     c_lib.chfl_atom_set_property.argtypes = [Atom, c_char_p, Property]
     c_lib.chfl_atom_set_property.restype = chfl_status
     c_lib.chfl_atom_set_property.errcheck = _check_return_code
 
-    # Function "chfl_atom_get_property", at atom.h:199
+    # Function "chfl_atom_get_property", at atom.h:248:17
     c_lib.chfl_atom_get_property.argtypes = [Atom, c_char_p]
     c_lib.chfl_atom_get_property.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_atom_free", at atom.h:207
-    c_lib.chfl_atom_free.argtypes = [Atom]
-    c_lib.chfl_atom_free.restype = chfl_status
-    c_lib.chfl_atom_free.errcheck = _check_return_code
-
-    # Function "chfl_residue", at residue.h:20
+    # Function "chfl_residue", at residue.h:20:16
     c_lib.chfl_residue.argtypes = [c_char_p]
     c_lib.chfl_residue.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_with_id", at residue.h:30
+    # Function "chfl_residue_with_id", at residue.h:30:16
     c_lib.chfl_residue_with_id.argtypes = [c_char_p, c_uint64]
     c_lib.chfl_residue_with_id.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_from_topology", at residue.h:46
+    # Function "chfl_residue_from_topology", at residue.h:52:22
     c_lib.chfl_residue_from_topology.argtypes = [Topology, c_uint64]
     c_lib.chfl_residue_from_topology.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_for_atom", at residue.h:62
+    # Function "chfl_residue_for_atom", at residue.h:73:22
     c_lib.chfl_residue_for_atom.argtypes = [Topology, c_uint64]
     c_lib.chfl_residue_for_atom.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_copy", at residue.h:74
+    # Function "chfl_residue_copy", at residue.h:85:16
     c_lib.chfl_residue_copy.argtypes = [Residue]
     c_lib.chfl_residue_copy.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_atoms_count", at residue.h:81
+    # Function "chfl_residue_atoms_count", at residue.h:92:14
     c_lib.chfl_residue_atoms_count.argtypes = [Residue, POINTER(c_uint64)]
     c_lib.chfl_residue_atoms_count.restype = chfl_status
     c_lib.chfl_residue_atoms_count.errcheck = _check_return_code
 
-    # Function "chfl_residue_atoms", at residue.h:95
+    # Function "chfl_residue_atoms", at residue.h:106:14
     c_lib.chfl_residue_atoms.argtypes = [Residue, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=1), c_uint64]
     c_lib.chfl_residue_atoms.restype = chfl_status
     c_lib.chfl_residue_atoms.errcheck = _check_return_code
 
-    # Function "chfl_residue_id", at residue.h:108
+    # Function "chfl_residue_id", at residue.h:119:14
     c_lib.chfl_residue_id.argtypes = [Residue, POINTER(c_uint64)]
     c_lib.chfl_residue_id.restype = chfl_status
     c_lib.chfl_residue_id.errcheck = _check_return_code
 
-    # Function "chfl_residue_name", at residue.h:120
+    # Function "chfl_residue_name", at residue.h:131:14
     c_lib.chfl_residue_name.argtypes = [Residue, c_char_p, c_uint64]
     c_lib.chfl_residue_name.restype = chfl_status
     c_lib.chfl_residue_name.errcheck = _check_return_code
 
-    # Function "chfl_residue_add_atom", at residue.h:129
+    # Function "chfl_residue_add_atom", at residue.h:140:14
     c_lib.chfl_residue_add_atom.argtypes = [Residue, c_uint64]
     c_lib.chfl_residue_add_atom.restype = chfl_status
     c_lib.chfl_residue_add_atom.errcheck = _check_return_code
 
-    # Function "chfl_residue_contains", at residue.h:139
+    # Function "chfl_residue_contains", at residue.h:150:14
     c_lib.chfl_residue_contains.argtypes = [Residue, c_uint64, POINTER(c_bool)]
     c_lib.chfl_residue_contains.restype = chfl_status
     c_lib.chfl_residue_contains.errcheck = _check_return_code
 
-    # Function "chfl_residue_free", at residue.h:147
-    c_lib.chfl_residue_free.argtypes = [Residue]
-    c_lib.chfl_residue_free.restype = chfl_status
-    c_lib.chfl_residue_free.errcheck = _check_return_code
+    # Function "chfl_residue_properties_count", at residue.h:159:14
+    c_lib.chfl_residue_properties_count.argtypes = [Residue, POINTER(c_uint64)]
+    c_lib.chfl_residue_properties_count.restype = chfl_status
+    c_lib.chfl_residue_properties_count.errcheck = _check_return_code
 
-    # Function "chfl_topology", at topology.h:20
+    # Function "chfl_residue_list_properties", at residue.h:175:14
+    c_lib.chfl_residue_list_properties.argtypes = [Residue, ndpointer(c_char, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    c_lib.chfl_residue_list_properties.restype = chfl_status
+    c_lib.chfl_residue_list_properties.errcheck = _check_return_code
+
+    # Function "chfl_residue_set_property", at residue.h:187:14
+    c_lib.chfl_residue_set_property.argtypes = [Residue, c_char_p, Property]
+    c_lib.chfl_residue_set_property.restype = chfl_status
+    c_lib.chfl_residue_set_property.errcheck = _check_return_code
+
+    # Function "chfl_residue_get_property", at residue.h:201:17
+    c_lib.chfl_residue_get_property.argtypes = [Residue, c_char_p]
+    c_lib.chfl_residue_get_property.restype = POINTER(CHFL_PROPERTY)
+
+    # Function "chfl_topology", at topology.h:20:17
     c_lib.chfl_topology.argtypes = []
     c_lib.chfl_topology.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_from_frame", at topology.h:30
+    # Function "chfl_topology_from_frame", at topology.h:34:23
     c_lib.chfl_topology_from_frame.argtypes = [Frame]
     c_lib.chfl_topology_from_frame.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_copy", at topology.h:40
+    # Function "chfl_topology_copy", at topology.h:44:17
     c_lib.chfl_topology_copy.argtypes = [Topology]
     c_lib.chfl_topology_copy.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_atoms_count", at topology.h:48
+    # Function "chfl_topology_atoms_count", at topology.h:52:14
     c_lib.chfl_topology_atoms_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_atoms_count.restype = chfl_status
     c_lib.chfl_topology_atoms_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_resize", at topology.h:60
+    # Function "chfl_topology_resize", at topology.h:64:14
     c_lib.chfl_topology_resize.argtypes = [Topology, c_uint64]
     c_lib.chfl_topology_resize.restype = chfl_status
     c_lib.chfl_topology_resize.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_atom", at topology.h:67
+    # Function "chfl_topology_add_atom", at topology.h:71:14
     c_lib.chfl_topology_add_atom.argtypes = [Topology, Atom]
     c_lib.chfl_topology_add_atom.restype = chfl_status
     c_lib.chfl_topology_add_atom.errcheck = _check_return_code
 
-    # Function "chfl_topology_remove", at topology.h:78
+    # Function "chfl_topology_remove", at topology.h:82:14
     c_lib.chfl_topology_remove.argtypes = [Topology, c_uint64]
     c_lib.chfl_topology_remove.restype = chfl_status
     c_lib.chfl_topology_remove.errcheck = _check_return_code
 
-    # Function "chfl_topology_bonds_count", at topology.h:87
+    # Function "chfl_topology_bonds_count", at topology.h:91:14
     c_lib.chfl_topology_bonds_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_bonds_count.restype = chfl_status
     c_lib.chfl_topology_bonds_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_angles_count", at topology.h:96
+    # Function "chfl_topology_angles_count", at topology.h:100:14
     c_lib.chfl_topology_angles_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_angles_count.restype = chfl_status
     c_lib.chfl_topology_angles_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_dihedrals_count", at topology.h:105
+    # Function "chfl_topology_dihedrals_count", at topology.h:109:14
     c_lib.chfl_topology_dihedrals_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_dihedrals_count.restype = chfl_status
     c_lib.chfl_topology_dihedrals_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_impropers_count", at topology.h:114
+    # Function "chfl_topology_impropers_count", at topology.h:118:14
     c_lib.chfl_topology_impropers_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_impropers_count.restype = chfl_status
     c_lib.chfl_topology_impropers_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_bonds", at topology.h:127
+    # Function "chfl_topology_bonds", at topology.h:131:14
     c_lib.chfl_topology_bonds.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_bonds.restype = chfl_status
     c_lib.chfl_topology_bonds.errcheck = _check_return_code
 
-    # Function "chfl_topology_angles", at topology.h:140
+    # Function "chfl_topology_angles", at topology.h:144:14
     c_lib.chfl_topology_angles.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_angles.restype = chfl_status
     c_lib.chfl_topology_angles.errcheck = _check_return_code
 
-    # Function "chfl_topology_dihedrals", at topology.h:154
+    # Function "chfl_topology_dihedrals", at topology.h:158:14
     c_lib.chfl_topology_dihedrals.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_dihedrals.restype = chfl_status
     c_lib.chfl_topology_dihedrals.errcheck = _check_return_code
 
-    # Function "chfl_topology_impropers", at topology.h:168
+    # Function "chfl_topology_impropers", at topology.h:172:14
     c_lib.chfl_topology_impropers.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_impropers.restype = chfl_status
     c_lib.chfl_topology_impropers.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_bond", at topology.h:177
+    # Function "chfl_topology_add_bond", at topology.h:181:14
     c_lib.chfl_topology_add_bond.argtypes = [Topology, c_uint64, c_uint64]
     c_lib.chfl_topology_add_bond.restype = chfl_status
     c_lib.chfl_topology_add_bond.errcheck = _check_return_code
 
-    # Function "chfl_topology_remove_bond", at topology.h:189
+    # Function "chfl_topology_remove_bond", at topology.h:193:14
     c_lib.chfl_topology_remove_bond.argtypes = [Topology, c_uint64, c_uint64]
     c_lib.chfl_topology_remove_bond.restype = chfl_status
     c_lib.chfl_topology_remove_bond.errcheck = _check_return_code
 
-    # Function "chfl_topology_residues_count", at topology.h:199
+    # Function "chfl_topology_residues_count", at topology.h:203:14
     c_lib.chfl_topology_residues_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_residues_count.restype = chfl_status
     c_lib.chfl_topology_residues_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_residue", at topology.h:211
+    # Function "chfl_topology_add_residue", at topology.h:215:14
     c_lib.chfl_topology_add_residue.argtypes = [Topology, Residue]
     c_lib.chfl_topology_add_residue.restype = chfl_status
     c_lib.chfl_topology_add_residue.errcheck = _check_return_code
 
-    # Function "chfl_topology_residues_linked", at topology.h:222
+    # Function "chfl_topology_residues_linked", at topology.h:226:14
     c_lib.chfl_topology_residues_linked.argtypes = [Topology, Residue, Residue, POINTER(c_bool)]
     c_lib.chfl_topology_residues_linked.restype = chfl_status
     c_lib.chfl_topology_residues_linked.errcheck = _check_return_code
 
-    # Function "chfl_topology_free", at topology.h:233
-    c_lib.chfl_topology_free.argtypes = [Topology]
-    c_lib.chfl_topology_free.restype = chfl_status
-    c_lib.chfl_topology_free.errcheck = _check_return_code
+    # Function "chfl_topology_bond_with_order", at topology.h:239:14
+    c_lib.chfl_topology_bond_with_order.argtypes = [Topology, c_uint64, c_uint64, chfl_bond_order]
+    c_lib.chfl_topology_bond_with_order.restype = chfl_status
+    c_lib.chfl_topology_bond_with_order.errcheck = _check_return_code
 
-    # Function "chfl_cell", at cell.h:33
+    # Function "chfl_topology_bond_orders", at topology.h:253:14
+    c_lib.chfl_topology_bond_orders.argtypes = [Topology, ndpointer(chfl_bond_order, flags="C_CONTIGUOUS", ndim=1), c_uint64]
+    c_lib.chfl_topology_bond_orders.restype = chfl_status
+    c_lib.chfl_topology_bond_orders.errcheck = _check_return_code
+
+    # Function "chfl_topology_bond_order", at topology.h:266:14
+    c_lib.chfl_topology_bond_order.argtypes = [Topology, c_uint64, c_uint64, POINTER(chfl_bond_order)]
+    c_lib.chfl_topology_bond_order.restype = chfl_status
+    c_lib.chfl_topology_bond_order.errcheck = _check_return_code
+
+    # Function "chfl_cell", at cell.h:33:13
     c_lib.chfl_cell.argtypes = [chfl_vector3d]
     c_lib.chfl_cell.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_triclinic", at cell.h:50
+    # Function "chfl_cell_triclinic", at cell.h:50:13
     c_lib.chfl_cell_triclinic.argtypes = [chfl_vector3d, chfl_vector3d]
     c_lib.chfl_cell_triclinic.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_from_frame", at cell.h:62
+    # Function "chfl_cell_from_frame", at cell.h:72:13
     c_lib.chfl_cell_from_frame.argtypes = [Frame]
     c_lib.chfl_cell_from_frame.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_copy", at cell.h:72
+    # Function "chfl_cell_copy", at cell.h:82:13
     c_lib.chfl_cell_copy.argtypes = [UnitCell]
     c_lib.chfl_cell_copy.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_volume", at cell.h:79
+    # Function "chfl_cell_volume", at cell.h:89:14
     c_lib.chfl_cell_volume.argtypes = [UnitCell, POINTER(c_double)]
     c_lib.chfl_cell_volume.restype = chfl_status
     c_lib.chfl_cell_volume.errcheck = _check_return_code
 
-    # Function "chfl_cell_lengths", at cell.h:88
+    # Function "chfl_cell_lengths", at cell.h:98:14
     c_lib.chfl_cell_lengths.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_lengths.restype = chfl_status
     c_lib.chfl_cell_lengths.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_lengths", at cell.h:99
+    # Function "chfl_cell_set_lengths", at cell.h:109:14
     c_lib.chfl_cell_set_lengths.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_set_lengths.restype = chfl_status
     c_lib.chfl_cell_set_lengths.errcheck = _check_return_code
 
-    # Function "chfl_cell_angles", at cell.h:108
+    # Function "chfl_cell_angles", at cell.h:118:14
     c_lib.chfl_cell_angles.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_angles.restype = chfl_status
     c_lib.chfl_cell_angles.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_angles", at cell.h:121
+    # Function "chfl_cell_set_angles", at cell.h:131:14
     c_lib.chfl_cell_set_angles.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_set_angles.restype = chfl_status
     c_lib.chfl_cell_set_angles.errcheck = _check_return_code
 
-    # Function "chfl_cell_matrix", at cell.h:139
+    # Function "chfl_cell_matrix", at cell.h:149:14
     c_lib.chfl_cell_matrix.argtypes = [UnitCell, ARRAY(chfl_vector3d, (3))]
     c_lib.chfl_cell_matrix.restype = chfl_status
     c_lib.chfl_cell_matrix.errcheck = _check_return_code
 
-    # Function "chfl_cell_shape", at cell.h:148
+    # Function "chfl_cell_shape", at cell.h:158:14
     c_lib.chfl_cell_shape.argtypes = [UnitCell, POINTER(chfl_cellshape)]
     c_lib.chfl_cell_shape.restype = chfl_status
     c_lib.chfl_cell_shape.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_shape", at cell.h:157
+    # Function "chfl_cell_set_shape", at cell.h:167:14
     c_lib.chfl_cell_set_shape.argtypes = [UnitCell, chfl_cellshape]
     c_lib.chfl_cell_set_shape.restype = chfl_status
     c_lib.chfl_cell_set_shape.errcheck = _check_return_code
 
-    # Function "chfl_cell_wrap", at cell.h:166
+    # Function "chfl_cell_wrap", at cell.h:176:14
     c_lib.chfl_cell_wrap.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_wrap.restype = chfl_status
     c_lib.chfl_cell_wrap.errcheck = _check_return_code
 
-    # Function "chfl_cell_free", at cell.h:174
-    c_lib.chfl_cell_free.argtypes = [UnitCell]
-    c_lib.chfl_cell_free.restype = chfl_status
-    c_lib.chfl_cell_free.errcheck = _check_return_code
-
-    # Function "chfl_frame", at frame.h:20
+    # Function "chfl_frame", at frame.h:20:14
     c_lib.chfl_frame.argtypes = []
     c_lib.chfl_frame.restype = POINTER(CHFL_FRAME)
 
-    # Function "chfl_frame_copy", at frame.h:30
+    # Function "chfl_frame_copy", at frame.h:30:14
     c_lib.chfl_frame_copy.argtypes = [Frame]
     c_lib.chfl_frame_copy.restype = POINTER(CHFL_FRAME)
 
-    # Function "chfl_frame_atoms_count", at frame.h:38
+    # Function "chfl_frame_atoms_count", at frame.h:38:14
     c_lib.chfl_frame_atoms_count.argtypes = [Frame, POINTER(c_uint64)]
     c_lib.chfl_frame_atoms_count.restype = chfl_status
     c_lib.chfl_frame_atoms_count.errcheck = _check_return_code
 
-    # Function "chfl_frame_positions", at frame.h:57
+    # Function "chfl_frame_positions", at frame.h:57:14
     c_lib.chfl_frame_positions.argtypes = [Frame, POINTER(POINTER(chfl_vector3d)), POINTER(c_uint64)]
     c_lib.chfl_frame_positions.restype = chfl_status
     c_lib.chfl_frame_positions.errcheck = _check_return_code
 
-    # Function "chfl_frame_velocities", at frame.h:80
+    # Function "chfl_frame_velocities", at frame.h:80:14
     c_lib.chfl_frame_velocities.argtypes = [Frame, POINTER(POINTER(chfl_vector3d)), POINTER(c_uint64)]
     c_lib.chfl_frame_velocities.restype = chfl_status
     c_lib.chfl_frame_velocities.errcheck = _check_return_code
 
-    # Function "chfl_frame_add_atom", at frame.h:92
+    # Function "chfl_frame_add_atom", at frame.h:92:14
     c_lib.chfl_frame_add_atom.argtypes = [Frame, Atom, chfl_vector3d, chfl_vector3d]
     c_lib.chfl_frame_add_atom.restype = chfl_status
     c_lib.chfl_frame_add_atom.errcheck = _check_return_code
 
-    # Function "chfl_frame_remove", at frame.h:105
+    # Function "chfl_frame_remove", at frame.h:105:14
     c_lib.chfl_frame_remove.argtypes = [Frame, c_uint64]
     c_lib.chfl_frame_remove.restype = chfl_status
     c_lib.chfl_frame_remove.errcheck = _check_return_code
 
-    # Function "chfl_frame_resize", at frame.h:117
+    # Function "chfl_frame_resize", at frame.h:117:14
     c_lib.chfl_frame_resize.argtypes = [Frame, c_uint64]
     c_lib.chfl_frame_resize.restype = chfl_status
     c_lib.chfl_frame_resize.errcheck = _check_return_code
 
-    # Function "chfl_frame_add_velocities", at frame.h:129
+    # Function "chfl_frame_add_velocities", at frame.h:129:14
     c_lib.chfl_frame_add_velocities.argtypes = [Frame]
     c_lib.chfl_frame_add_velocities.restype = chfl_status
     c_lib.chfl_frame_add_velocities.errcheck = _check_return_code
 
-    # Function "chfl_frame_has_velocities", at frame.h:137
+    # Function "chfl_frame_has_velocities", at frame.h:137:14
     c_lib.chfl_frame_has_velocities.argtypes = [Frame, POINTER(c_bool)]
     c_lib.chfl_frame_has_velocities.restype = chfl_status
     c_lib.chfl_frame_has_velocities.errcheck = _check_return_code
 
-    # Function "chfl_frame_set_cell", at frame.h:146
+    # Function "chfl_frame_set_cell", at frame.h:146:14
     c_lib.chfl_frame_set_cell.argtypes = [Frame, UnitCell]
     c_lib.chfl_frame_set_cell.restype = chfl_status
     c_lib.chfl_frame_set_cell.errcheck = _check_return_code
 
-    # Function "chfl_frame_set_topology", at frame.h:158
+    # Function "chfl_frame_set_topology", at frame.h:158:14
     c_lib.chfl_frame_set_topology.argtypes = [Frame, Topology]
     c_lib.chfl_frame_set_topology.restype = chfl_status
     c_lib.chfl_frame_set_topology.errcheck = _check_return_code
 
-    # Function "chfl_frame_step", at frame.h:168
+    # Function "chfl_frame_step", at frame.h:168:14
     c_lib.chfl_frame_step.argtypes = [Frame, POINTER(c_uint64)]
     c_lib.chfl_frame_step.restype = chfl_status
     c_lib.chfl_frame_step.errcheck = _check_return_code
 
-    # Function "chfl_frame_set_step", at frame.h:177
+    # Function "chfl_frame_set_step", at frame.h:177:14
     c_lib.chfl_frame_set_step.argtypes = [Frame, c_uint64]
     c_lib.chfl_frame_set_step.restype = chfl_status
     c_lib.chfl_frame_set_step.errcheck = _check_return_code
 
-    # Function "chfl_frame_guess_topology", at frame.h:189
-    c_lib.chfl_frame_guess_topology.argtypes = [Frame]
-    c_lib.chfl_frame_guess_topology.restype = chfl_status
-    c_lib.chfl_frame_guess_topology.errcheck = _check_return_code
+    # Function "chfl_frame_guess_bonds", at frame.h:189:14
+    c_lib.chfl_frame_guess_bonds.argtypes = [Frame]
+    c_lib.chfl_frame_guess_bonds.restype = chfl_status
+    c_lib.chfl_frame_guess_bonds.errcheck = _check_return_code
 
-    # Function "chfl_frame_distance", at frame.h:198
+    # Function "chfl_frame_distance", at frame.h:198:14
     c_lib.chfl_frame_distance.argtypes = [Frame, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_distance.restype = chfl_status
     c_lib.chfl_frame_distance.errcheck = _check_return_code
 
-    # Function "chfl_frame_angle", at frame.h:209
+    # Function "chfl_frame_angle", at frame.h:209:14
     c_lib.chfl_frame_angle.argtypes = [Frame, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_angle.restype = chfl_status
     c_lib.chfl_frame_angle.errcheck = _check_return_code
 
-    # Function "chfl_frame_dihedral", at frame.h:220
+    # Function "chfl_frame_dihedral", at frame.h:220:14
     c_lib.chfl_frame_dihedral.argtypes = [Frame, c_uint64, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_dihedral.restype = chfl_status
     c_lib.chfl_frame_dihedral.errcheck = _check_return_code
 
-    # Function "chfl_frame_out_of_plane", at frame.h:234
+    # Function "chfl_frame_out_of_plane", at frame.h:234:14
     c_lib.chfl_frame_out_of_plane.argtypes = [Frame, c_uint64, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_out_of_plane.restype = chfl_status
     c_lib.chfl_frame_out_of_plane.errcheck = _check_return_code
 
-    # Function "chfl_frame_set_property", at frame.h:246
+    # Function "chfl_frame_properties_count", at frame.h:243:14
+    c_lib.chfl_frame_properties_count.argtypes = [Frame, POINTER(c_uint64)]
+    c_lib.chfl_frame_properties_count.restype = chfl_status
+    c_lib.chfl_frame_properties_count.errcheck = _check_return_code
+
+    # Function "chfl_frame_list_properties", at frame.h:259:14
+    c_lib.chfl_frame_list_properties.argtypes = [Frame, ndpointer(c_char, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    c_lib.chfl_frame_list_properties.restype = chfl_status
+    c_lib.chfl_frame_list_properties.errcheck = _check_return_code
+
+    # Function "chfl_frame_set_property", at frame.h:271:14
     c_lib.chfl_frame_set_property.argtypes = [Frame, c_char_p, Property]
     c_lib.chfl_frame_set_property.restype = chfl_status
     c_lib.chfl_frame_set_property.errcheck = _check_return_code
 
-    # Function "chfl_frame_get_property", at frame.h:260
+    # Function "chfl_frame_get_property", at frame.h:285:17
     c_lib.chfl_frame_get_property.argtypes = [Frame, c_char_p]
     c_lib.chfl_frame_get_property.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_frame_add_bond", at frame.h:269
+    # Function "chfl_frame_add_bond", at frame.h:294:14
     c_lib.chfl_frame_add_bond.argtypes = [Frame, c_uint64, c_uint64]
     c_lib.chfl_frame_add_bond.restype = chfl_status
     c_lib.chfl_frame_add_bond.errcheck = _check_return_code
 
-    # Function "chfl_frame_remove_bond", at frame.h:281
+    # Function "chfl_frame_bond_with_order", at frame.h:304:14
+    c_lib.chfl_frame_bond_with_order.argtypes = [Frame, c_uint64, c_uint64, chfl_bond_order]
+    c_lib.chfl_frame_bond_with_order.restype = chfl_status
+    c_lib.chfl_frame_bond_with_order.errcheck = _check_return_code
+
+    # Function "chfl_frame_remove_bond", at frame.h:316:14
     c_lib.chfl_frame_remove_bond.argtypes = [Frame, c_uint64, c_uint64]
     c_lib.chfl_frame_remove_bond.restype = chfl_status
     c_lib.chfl_frame_remove_bond.errcheck = _check_return_code
 
-    # Function "chfl_frame_add_residue", at frame.h:293
+    # Function "chfl_frame_add_residue", at frame.h:328:14
     c_lib.chfl_frame_add_residue.argtypes = [Frame, Residue]
     c_lib.chfl_frame_add_residue.restype = chfl_status
     c_lib.chfl_frame_add_residue.errcheck = _check_return_code
 
-    # Function "chfl_frame_free", at frame.h:301
-    c_lib.chfl_frame_free.argtypes = [Frame]
-    c_lib.chfl_frame_free.restype = chfl_status
-    c_lib.chfl_frame_free.errcheck = _check_return_code
-
-    # Function "chfl_trajectory_open", at trajectory.h:22
+    # Function "chfl_trajectory_open", at trajectory.h:22:19
     c_lib.chfl_trajectory_open.argtypes = [c_char_p, c_char]
     c_lib.chfl_trajectory_open.restype = POINTER(CHFL_TRAJECTORY)
 
-    # Function "chfl_trajectory_with_format", at trajectory.h:39
+    # Function "chfl_trajectory_with_format", at trajectory.h:39:19
     c_lib.chfl_trajectory_with_format.argtypes = [c_char_p, c_char, c_char_p]
     c_lib.chfl_trajectory_with_format.restype = POINTER(CHFL_TRAJECTORY)
 
-    # Function "chfl_trajectory_read", at trajectory.h:51
+    # Function "chfl_trajectory_path", at trajectory.h:52:14
+    c_lib.chfl_trajectory_path.argtypes = [Trajectory, POINTER(POINTER(c_char))]
+    c_lib.chfl_trajectory_path.restype = chfl_status
+    c_lib.chfl_trajectory_path.errcheck = _check_return_code
+
+    # Function "chfl_trajectory_read", at trajectory.h:64:14
     c_lib.chfl_trajectory_read.argtypes = [Trajectory, Frame]
     c_lib.chfl_trajectory_read.restype = chfl_status
     c_lib.chfl_trajectory_read.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_read_step", at trajectory.h:63
+    # Function "chfl_trajectory_read_step", at trajectory.h:76:14
     c_lib.chfl_trajectory_read_step.argtypes = [Trajectory, c_uint64, Frame]
     c_lib.chfl_trajectory_read_step.restype = chfl_status
     c_lib.chfl_trajectory_read_step.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_write", at trajectory.h:72
+    # Function "chfl_trajectory_write", at trajectory.h:85:14
     c_lib.chfl_trajectory_write.argtypes = [Trajectory, Frame]
     c_lib.chfl_trajectory_write.restype = chfl_status
     c_lib.chfl_trajectory_write.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_set_topology", at trajectory.h:83
+    # Function "chfl_trajectory_set_topology", at trajectory.h:96:14
     c_lib.chfl_trajectory_set_topology.argtypes = [Trajectory, Topology]
     c_lib.chfl_trajectory_set_topology.restype = chfl_status
     c_lib.chfl_trajectory_set_topology.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_topology_file", at trajectory.h:97
+    # Function "chfl_trajectory_topology_file", at trajectory.h:110:14
     c_lib.chfl_trajectory_topology_file.argtypes = [Trajectory, c_char_p, c_char_p]
     c_lib.chfl_trajectory_topology_file.restype = chfl_status
     c_lib.chfl_trajectory_topology_file.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_set_cell", at trajectory.h:107
+    # Function "chfl_trajectory_set_cell", at trajectory.h:120:14
     c_lib.chfl_trajectory_set_cell.argtypes = [Trajectory, UnitCell]
     c_lib.chfl_trajectory_set_cell.restype = chfl_status
     c_lib.chfl_trajectory_set_cell.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_nsteps", at trajectory.h:117
+    # Function "chfl_trajectory_nsteps", at trajectory.h:130:14
     c_lib.chfl_trajectory_nsteps.argtypes = [Trajectory, POINTER(c_uint64)]
     c_lib.chfl_trajectory_nsteps.restype = chfl_status
     c_lib.chfl_trajectory_nsteps.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_close", at trajectory.h:128
-    c_lib.chfl_trajectory_close.argtypes = [Trajectory]
-    c_lib.chfl_trajectory_close.restype = chfl_status
-    c_lib.chfl_trajectory_close.errcheck = _check_return_code
-
-    # Function "chfl_selection", at selection.h:20
+    # Function "chfl_selection", at selection.h:20:18
     c_lib.chfl_selection.argtypes = [c_char_p]
     c_lib.chfl_selection.restype = POINTER(CHFL_SELECTION)
 
-    # Function "chfl_selection_copy", at selection.h:33
+    # Function "chfl_selection_copy", at selection.h:33:18
     c_lib.chfl_selection_copy.argtypes = [Selection]
     c_lib.chfl_selection_copy.restype = POINTER(CHFL_SELECTION)
 
-    # Function "chfl_selection_size", at selection.h:45
+    # Function "chfl_selection_size", at selection.h:45:14
     c_lib.chfl_selection_size.argtypes = [Selection, POINTER(c_uint64)]
     c_lib.chfl_selection_size.restype = chfl_status
     c_lib.chfl_selection_size.errcheck = _check_return_code
 
-    # Function "chfl_selection_string", at selection.h:58
+    # Function "chfl_selection_string", at selection.h:58:14
     c_lib.chfl_selection_string.argtypes = [Selection, c_char_p, c_uint64]
     c_lib.chfl_selection_string.restype = chfl_status
     c_lib.chfl_selection_string.errcheck = _check_return_code
 
-    # Function "chfl_selection_evaluate", at selection.h:71
+    # Function "chfl_selection_evaluate", at selection.h:71:14
     c_lib.chfl_selection_evaluate.argtypes = [Selection, Frame, POINTER(c_uint64)]
     c_lib.chfl_selection_evaluate.restype = chfl_status
     c_lib.chfl_selection_evaluate.errcheck = _check_return_code
 
-    # Function "chfl_selection_matches", at selection.h:97
+    # Function "chfl_selection_matches", at selection.h:97:14
     c_lib.chfl_selection_matches.argtypes = [Selection, ndpointer(chfl_match, flags="C_CONTIGUOUS", ndim=1), c_uint64]
     c_lib.chfl_selection_matches.restype = chfl_status
     c_lib.chfl_selection_matches.errcheck = _check_return_code
-
-    # Function "chfl_selection_free", at selection.h:105
-    c_lib.chfl_selection_free.argtypes = [Selection]
-    c_lib.chfl_selection_free.restype = chfl_status
-    c_lib.chfl_selection_free.errcheck = _check_return_code

--- a/chemfiles/ffi.py
+++ b/chemfiles/ffi.py
@@ -119,611 +119,611 @@ def set_interface(c_lib):
     c_lib.chfl_trajectory_close.argtypes = [Trajectory]
     # End of manually defined functions
 
-    # Function "chfl_version", at types.h:145:14
+    # Function "chfl_version", at types.h:145
     c_lib.chfl_version.argtypes = []
     c_lib.chfl_version.restype = c_char_p
 
-    # Function "chfl_last_error", at misc.h:19:14
+    # Function "chfl_last_error", at misc.h:19
     c_lib.chfl_last_error.argtypes = []
     c_lib.chfl_last_error.restype = c_char_p
 
-    # Function "chfl_clear_errors", at misc.h:29:14
+    # Function "chfl_clear_errors", at misc.h:29
     c_lib.chfl_clear_errors.argtypes = []
     c_lib.chfl_clear_errors.restype = chfl_status
     c_lib.chfl_clear_errors.errcheck = _check_return_code
 
-    # Function "chfl_set_warning_callback", at misc.h:38:14
+    # Function "chfl_set_warning_callback", at misc.h:38
     c_lib.chfl_set_warning_callback.argtypes = [chfl_warning_callback]
     c_lib.chfl_set_warning_callback.restype = chfl_status
     c_lib.chfl_set_warning_callback.errcheck = _check_return_code
 
-    # Function "chfl_add_configuration", at misc.h:54:14
+    # Function "chfl_add_configuration", at misc.h:54
     c_lib.chfl_add_configuration.argtypes = [c_char_p]
     c_lib.chfl_add_configuration.restype = chfl_status
     c_lib.chfl_add_configuration.errcheck = _check_return_code
 
-    # Function "chfl_property_bool", at property.h:32:17
+    # Function "chfl_property_bool", at property.h:32
     c_lib.chfl_property_bool.argtypes = [c_bool]
     c_lib.chfl_property_bool.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_property_double", at property.h:42:17
+    # Function "chfl_property_double", at property.h:42
     c_lib.chfl_property_double.argtypes = [c_double]
     c_lib.chfl_property_double.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_property_string", at property.h:52:17
+    # Function "chfl_property_string", at property.h:52
     c_lib.chfl_property_string.argtypes = [c_char_p]
     c_lib.chfl_property_string.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_property_vector3d", at property.h:62:17
+    # Function "chfl_property_vector3d", at property.h:62
     c_lib.chfl_property_vector3d.argtypes = [chfl_vector3d]
     c_lib.chfl_property_vector3d.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_property_get_kind", at property.h:69:14
+    # Function "chfl_property_get_kind", at property.h:69
     c_lib.chfl_property_get_kind.argtypes = [Property, POINTER(chfl_property_kind)]
     c_lib.chfl_property_get_kind.restype = chfl_status
     c_lib.chfl_property_get_kind.errcheck = _check_return_code
 
-    # Function "chfl_property_get_bool", at property.h:82:14
+    # Function "chfl_property_get_bool", at property.h:82
     c_lib.chfl_property_get_bool.argtypes = [Property, POINTER(c_bool)]
     c_lib.chfl_property_get_bool.restype = chfl_status
     c_lib.chfl_property_get_bool.errcheck = _check_return_code
 
-    # Function "chfl_property_get_double", at property.h:95:14
+    # Function "chfl_property_get_double", at property.h:95
     c_lib.chfl_property_get_double.argtypes = [Property, POINTER(c_double)]
     c_lib.chfl_property_get_double.restype = chfl_status
     c_lib.chfl_property_get_double.errcheck = _check_return_code
 
-    # Function "chfl_property_get_string", at property.h:110:14
+    # Function "chfl_property_get_string", at property.h:110
     c_lib.chfl_property_get_string.argtypes = [Property, c_char_p, c_uint64]
     c_lib.chfl_property_get_string.restype = chfl_status
     c_lib.chfl_property_get_string.errcheck = _check_return_code
 
-    # Function "chfl_property_get_vector3d", at property.h:123:14
+    # Function "chfl_property_get_vector3d", at property.h:123
     c_lib.chfl_property_get_vector3d.argtypes = [Property, chfl_vector3d]
     c_lib.chfl_property_get_vector3d.restype = chfl_status
     c_lib.chfl_property_get_vector3d.errcheck = _check_return_code
 
-    # Function "chfl_atom", at atom.h:20:13
+    # Function "chfl_atom", at atom.h:20
     c_lib.chfl_atom.argtypes = [c_char_p]
     c_lib.chfl_atom.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_copy", at atom.h:30:13
+    # Function "chfl_atom_copy", at atom.h:30
     c_lib.chfl_atom_copy.argtypes = [Atom]
     c_lib.chfl_atom_copy.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_from_frame", at atom.h:54:13
+    # Function "chfl_atom_from_frame", at atom.h:54
     c_lib.chfl_atom_from_frame.argtypes = [Frame, c_uint64]
     c_lib.chfl_atom_from_frame.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_from_topology", at atom.h:77:13
+    # Function "chfl_atom_from_topology", at atom.h:77
     c_lib.chfl_atom_from_topology.argtypes = [Topology, c_uint64]
     c_lib.chfl_atom_from_topology.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_mass", at atom.h:88:14
+    # Function "chfl_atom_mass", at atom.h:88
     c_lib.chfl_atom_mass.argtypes = [Atom, POINTER(c_double)]
     c_lib.chfl_atom_mass.restype = chfl_status
     c_lib.chfl_atom_mass.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_mass", at atom.h:97:14
+    # Function "chfl_atom_set_mass", at atom.h:97
     c_lib.chfl_atom_set_mass.argtypes = [Atom, c_double]
     c_lib.chfl_atom_set_mass.restype = chfl_status
     c_lib.chfl_atom_set_mass.errcheck = _check_return_code
 
-    # Function "chfl_atom_charge", at atom.h:106:14
+    # Function "chfl_atom_charge", at atom.h:106
     c_lib.chfl_atom_charge.argtypes = [Atom, POINTER(c_double)]
     c_lib.chfl_atom_charge.restype = chfl_status
     c_lib.chfl_atom_charge.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_charge", at atom.h:115:14
+    # Function "chfl_atom_set_charge", at atom.h:115
     c_lib.chfl_atom_set_charge.argtypes = [Atom, c_double]
     c_lib.chfl_atom_set_charge.restype = chfl_status
     c_lib.chfl_atom_set_charge.errcheck = _check_return_code
 
-    # Function "chfl_atom_type", at atom.h:125:14
+    # Function "chfl_atom_type", at atom.h:125
     c_lib.chfl_atom_type.argtypes = [Atom, c_char_p, c_uint64]
     c_lib.chfl_atom_type.restype = chfl_status
     c_lib.chfl_atom_type.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_type", at atom.h:136:14
+    # Function "chfl_atom_set_type", at atom.h:136
     c_lib.chfl_atom_set_type.argtypes = [Atom, c_char_p]
     c_lib.chfl_atom_set_type.restype = chfl_status
     c_lib.chfl_atom_set_type.errcheck = _check_return_code
 
-    # Function "chfl_atom_name", at atom.h:146:14
+    # Function "chfl_atom_name", at atom.h:146
     c_lib.chfl_atom_name.argtypes = [Atom, c_char_p, c_uint64]
     c_lib.chfl_atom_name.restype = chfl_status
     c_lib.chfl_atom_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_name", at atom.h:157:14
+    # Function "chfl_atom_set_name", at atom.h:157
     c_lib.chfl_atom_set_name.argtypes = [Atom, c_char_p]
     c_lib.chfl_atom_set_name.restype = chfl_status
     c_lib.chfl_atom_set_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_full_name", at atom.h:167:14
+    # Function "chfl_atom_full_name", at atom.h:167
     c_lib.chfl_atom_full_name.argtypes = [Atom, c_char_p, c_uint64]
     c_lib.chfl_atom_full_name.restype = chfl_status
     c_lib.chfl_atom_full_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_vdw_radius", at atom.h:179:14
+    # Function "chfl_atom_vdw_radius", at atom.h:179
     c_lib.chfl_atom_vdw_radius.argtypes = [Atom, POINTER(c_double)]
     c_lib.chfl_atom_vdw_radius.restype = chfl_status
     c_lib.chfl_atom_vdw_radius.errcheck = _check_return_code
 
-    # Function "chfl_atom_covalent_radius", at atom.h:189:14
+    # Function "chfl_atom_covalent_radius", at atom.h:189
     c_lib.chfl_atom_covalent_radius.argtypes = [Atom, POINTER(c_double)]
     c_lib.chfl_atom_covalent_radius.restype = chfl_status
     c_lib.chfl_atom_covalent_radius.errcheck = _check_return_code
 
-    # Function "chfl_atom_atomic_number", at atom.h:199:14
+    # Function "chfl_atom_atomic_number", at atom.h:199
     c_lib.chfl_atom_atomic_number.argtypes = [Atom, POINTER(c_uint64)]
     c_lib.chfl_atom_atomic_number.restype = chfl_status
     c_lib.chfl_atom_atomic_number.errcheck = _check_return_code
 
-    # Function "chfl_atom_properties_count", at atom.h:206:14
+    # Function "chfl_atom_properties_count", at atom.h:206
     c_lib.chfl_atom_properties_count.argtypes = [Atom, POINTER(c_uint64)]
     c_lib.chfl_atom_properties_count.restype = chfl_status
     c_lib.chfl_atom_properties_count.errcheck = _check_return_code
 
-    # Function "chfl_atom_list_properties", at atom.h:222:14
-    c_lib.chfl_atom_list_properties.argtypes = [Atom, ndpointer(c_char, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    # Function "chfl_atom_list_properties", at atom.h:222
+    c_lib.chfl_atom_list_properties.argtypes = [Atom, POINTER(c_char_p), c_uint64]
     c_lib.chfl_atom_list_properties.restype = chfl_status
     c_lib.chfl_atom_list_properties.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_property", at atom.h:234:14
+    # Function "chfl_atom_set_property", at atom.h:234
     c_lib.chfl_atom_set_property.argtypes = [Atom, c_char_p, Property]
     c_lib.chfl_atom_set_property.restype = chfl_status
     c_lib.chfl_atom_set_property.errcheck = _check_return_code
 
-    # Function "chfl_atom_get_property", at atom.h:248:17
+    # Function "chfl_atom_get_property", at atom.h:248
     c_lib.chfl_atom_get_property.argtypes = [Atom, c_char_p]
     c_lib.chfl_atom_get_property.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_residue", at residue.h:20:16
+    # Function "chfl_residue", at residue.h:20
     c_lib.chfl_residue.argtypes = [c_char_p]
     c_lib.chfl_residue.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_with_id", at residue.h:30:16
+    # Function "chfl_residue_with_id", at residue.h:30
     c_lib.chfl_residue_with_id.argtypes = [c_char_p, c_uint64]
     c_lib.chfl_residue_with_id.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_from_topology", at residue.h:52:22
+    # Function "chfl_residue_from_topology", at residue.h:52
     c_lib.chfl_residue_from_topology.argtypes = [Topology, c_uint64]
     c_lib.chfl_residue_from_topology.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_for_atom", at residue.h:73:22
+    # Function "chfl_residue_for_atom", at residue.h:73
     c_lib.chfl_residue_for_atom.argtypes = [Topology, c_uint64]
     c_lib.chfl_residue_for_atom.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_copy", at residue.h:85:16
+    # Function "chfl_residue_copy", at residue.h:85
     c_lib.chfl_residue_copy.argtypes = [Residue]
     c_lib.chfl_residue_copy.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_atoms_count", at residue.h:92:14
+    # Function "chfl_residue_atoms_count", at residue.h:92
     c_lib.chfl_residue_atoms_count.argtypes = [Residue, POINTER(c_uint64)]
     c_lib.chfl_residue_atoms_count.restype = chfl_status
     c_lib.chfl_residue_atoms_count.errcheck = _check_return_code
 
-    # Function "chfl_residue_atoms", at residue.h:106:14
+    # Function "chfl_residue_atoms", at residue.h:106
     c_lib.chfl_residue_atoms.argtypes = [Residue, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=1), c_uint64]
     c_lib.chfl_residue_atoms.restype = chfl_status
     c_lib.chfl_residue_atoms.errcheck = _check_return_code
 
-    # Function "chfl_residue_id", at residue.h:119:14
+    # Function "chfl_residue_id", at residue.h:119
     c_lib.chfl_residue_id.argtypes = [Residue, POINTER(c_uint64)]
     c_lib.chfl_residue_id.restype = chfl_status
     c_lib.chfl_residue_id.errcheck = _check_return_code
 
-    # Function "chfl_residue_name", at residue.h:131:14
+    # Function "chfl_residue_name", at residue.h:131
     c_lib.chfl_residue_name.argtypes = [Residue, c_char_p, c_uint64]
     c_lib.chfl_residue_name.restype = chfl_status
     c_lib.chfl_residue_name.errcheck = _check_return_code
 
-    # Function "chfl_residue_add_atom", at residue.h:140:14
+    # Function "chfl_residue_add_atom", at residue.h:140
     c_lib.chfl_residue_add_atom.argtypes = [Residue, c_uint64]
     c_lib.chfl_residue_add_atom.restype = chfl_status
     c_lib.chfl_residue_add_atom.errcheck = _check_return_code
 
-    # Function "chfl_residue_contains", at residue.h:150:14
+    # Function "chfl_residue_contains", at residue.h:150
     c_lib.chfl_residue_contains.argtypes = [Residue, c_uint64, POINTER(c_bool)]
     c_lib.chfl_residue_contains.restype = chfl_status
     c_lib.chfl_residue_contains.errcheck = _check_return_code
 
-    # Function "chfl_residue_properties_count", at residue.h:159:14
+    # Function "chfl_residue_properties_count", at residue.h:159
     c_lib.chfl_residue_properties_count.argtypes = [Residue, POINTER(c_uint64)]
     c_lib.chfl_residue_properties_count.restype = chfl_status
     c_lib.chfl_residue_properties_count.errcheck = _check_return_code
 
-    # Function "chfl_residue_list_properties", at residue.h:175:14
-    c_lib.chfl_residue_list_properties.argtypes = [Residue, ndpointer(c_char, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    # Function "chfl_residue_list_properties", at residue.h:175
+    c_lib.chfl_residue_list_properties.argtypes = [Residue, POINTER(c_char_p), c_uint64]
     c_lib.chfl_residue_list_properties.restype = chfl_status
     c_lib.chfl_residue_list_properties.errcheck = _check_return_code
 
-    # Function "chfl_residue_set_property", at residue.h:187:14
+    # Function "chfl_residue_set_property", at residue.h:187
     c_lib.chfl_residue_set_property.argtypes = [Residue, c_char_p, Property]
     c_lib.chfl_residue_set_property.restype = chfl_status
     c_lib.chfl_residue_set_property.errcheck = _check_return_code
 
-    # Function "chfl_residue_get_property", at residue.h:201:17
+    # Function "chfl_residue_get_property", at residue.h:201
     c_lib.chfl_residue_get_property.argtypes = [Residue, c_char_p]
     c_lib.chfl_residue_get_property.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_topology", at topology.h:20:17
+    # Function "chfl_topology", at topology.h:20
     c_lib.chfl_topology.argtypes = []
     c_lib.chfl_topology.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_from_frame", at topology.h:34:23
+    # Function "chfl_topology_from_frame", at topology.h:34
     c_lib.chfl_topology_from_frame.argtypes = [Frame]
     c_lib.chfl_topology_from_frame.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_copy", at topology.h:44:17
+    # Function "chfl_topology_copy", at topology.h:44
     c_lib.chfl_topology_copy.argtypes = [Topology]
     c_lib.chfl_topology_copy.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_atoms_count", at topology.h:52:14
+    # Function "chfl_topology_atoms_count", at topology.h:52
     c_lib.chfl_topology_atoms_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_atoms_count.restype = chfl_status
     c_lib.chfl_topology_atoms_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_resize", at topology.h:64:14
+    # Function "chfl_topology_resize", at topology.h:64
     c_lib.chfl_topology_resize.argtypes = [Topology, c_uint64]
     c_lib.chfl_topology_resize.restype = chfl_status
     c_lib.chfl_topology_resize.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_atom", at topology.h:71:14
+    # Function "chfl_topology_add_atom", at topology.h:71
     c_lib.chfl_topology_add_atom.argtypes = [Topology, Atom]
     c_lib.chfl_topology_add_atom.restype = chfl_status
     c_lib.chfl_topology_add_atom.errcheck = _check_return_code
 
-    # Function "chfl_topology_remove", at topology.h:82:14
+    # Function "chfl_topology_remove", at topology.h:82
     c_lib.chfl_topology_remove.argtypes = [Topology, c_uint64]
     c_lib.chfl_topology_remove.restype = chfl_status
     c_lib.chfl_topology_remove.errcheck = _check_return_code
 
-    # Function "chfl_topology_bonds_count", at topology.h:91:14
+    # Function "chfl_topology_bonds_count", at topology.h:91
     c_lib.chfl_topology_bonds_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_bonds_count.restype = chfl_status
     c_lib.chfl_topology_bonds_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_angles_count", at topology.h:100:14
+    # Function "chfl_topology_angles_count", at topology.h:100
     c_lib.chfl_topology_angles_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_angles_count.restype = chfl_status
     c_lib.chfl_topology_angles_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_dihedrals_count", at topology.h:109:14
+    # Function "chfl_topology_dihedrals_count", at topology.h:109
     c_lib.chfl_topology_dihedrals_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_dihedrals_count.restype = chfl_status
     c_lib.chfl_topology_dihedrals_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_impropers_count", at topology.h:118:14
+    # Function "chfl_topology_impropers_count", at topology.h:118
     c_lib.chfl_topology_impropers_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_impropers_count.restype = chfl_status
     c_lib.chfl_topology_impropers_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_bonds", at topology.h:131:14
+    # Function "chfl_topology_bonds", at topology.h:131
     c_lib.chfl_topology_bonds.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_bonds.restype = chfl_status
     c_lib.chfl_topology_bonds.errcheck = _check_return_code
 
-    # Function "chfl_topology_angles", at topology.h:144:14
+    # Function "chfl_topology_angles", at topology.h:144
     c_lib.chfl_topology_angles.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_angles.restype = chfl_status
     c_lib.chfl_topology_angles.errcheck = _check_return_code
 
-    # Function "chfl_topology_dihedrals", at topology.h:158:14
+    # Function "chfl_topology_dihedrals", at topology.h:158
     c_lib.chfl_topology_dihedrals.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_dihedrals.restype = chfl_status
     c_lib.chfl_topology_dihedrals.errcheck = _check_return_code
 
-    # Function "chfl_topology_impropers", at topology.h:172:14
+    # Function "chfl_topology_impropers", at topology.h:172
     c_lib.chfl_topology_impropers.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_impropers.restype = chfl_status
     c_lib.chfl_topology_impropers.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_bond", at topology.h:181:14
+    # Function "chfl_topology_add_bond", at topology.h:181
     c_lib.chfl_topology_add_bond.argtypes = [Topology, c_uint64, c_uint64]
     c_lib.chfl_topology_add_bond.restype = chfl_status
     c_lib.chfl_topology_add_bond.errcheck = _check_return_code
 
-    # Function "chfl_topology_remove_bond", at topology.h:193:14
+    # Function "chfl_topology_remove_bond", at topology.h:193
     c_lib.chfl_topology_remove_bond.argtypes = [Topology, c_uint64, c_uint64]
     c_lib.chfl_topology_remove_bond.restype = chfl_status
     c_lib.chfl_topology_remove_bond.errcheck = _check_return_code
 
-    # Function "chfl_topology_residues_count", at topology.h:203:14
+    # Function "chfl_topology_residues_count", at topology.h:203
     c_lib.chfl_topology_residues_count.argtypes = [Topology, POINTER(c_uint64)]
     c_lib.chfl_topology_residues_count.restype = chfl_status
     c_lib.chfl_topology_residues_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_residue", at topology.h:215:14
+    # Function "chfl_topology_add_residue", at topology.h:215
     c_lib.chfl_topology_add_residue.argtypes = [Topology, Residue]
     c_lib.chfl_topology_add_residue.restype = chfl_status
     c_lib.chfl_topology_add_residue.errcheck = _check_return_code
 
-    # Function "chfl_topology_residues_linked", at topology.h:226:14
+    # Function "chfl_topology_residues_linked", at topology.h:226
     c_lib.chfl_topology_residues_linked.argtypes = [Topology, Residue, Residue, POINTER(c_bool)]
     c_lib.chfl_topology_residues_linked.restype = chfl_status
     c_lib.chfl_topology_residues_linked.errcheck = _check_return_code
 
-    # Function "chfl_topology_bond_with_order", at topology.h:239:14
+    # Function "chfl_topology_bond_with_order", at topology.h:239
     c_lib.chfl_topology_bond_with_order.argtypes = [Topology, c_uint64, c_uint64, chfl_bond_order]
     c_lib.chfl_topology_bond_with_order.restype = chfl_status
     c_lib.chfl_topology_bond_with_order.errcheck = _check_return_code
 
-    # Function "chfl_topology_bond_orders", at topology.h:253:14
+    # Function "chfl_topology_bond_orders", at topology.h:253
     c_lib.chfl_topology_bond_orders.argtypes = [Topology, ndpointer(chfl_bond_order, flags="C_CONTIGUOUS", ndim=1), c_uint64]
     c_lib.chfl_topology_bond_orders.restype = chfl_status
     c_lib.chfl_topology_bond_orders.errcheck = _check_return_code
 
-    # Function "chfl_topology_bond_order", at topology.h:266:14
+    # Function "chfl_topology_bond_order", at topology.h:266
     c_lib.chfl_topology_bond_order.argtypes = [Topology, c_uint64, c_uint64, POINTER(chfl_bond_order)]
     c_lib.chfl_topology_bond_order.restype = chfl_status
     c_lib.chfl_topology_bond_order.errcheck = _check_return_code
 
-    # Function "chfl_cell", at cell.h:33:13
+    # Function "chfl_cell", at cell.h:33
     c_lib.chfl_cell.argtypes = [chfl_vector3d]
     c_lib.chfl_cell.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_triclinic", at cell.h:50:13
+    # Function "chfl_cell_triclinic", at cell.h:50
     c_lib.chfl_cell_triclinic.argtypes = [chfl_vector3d, chfl_vector3d]
     c_lib.chfl_cell_triclinic.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_from_frame", at cell.h:72:13
+    # Function "chfl_cell_from_frame", at cell.h:72
     c_lib.chfl_cell_from_frame.argtypes = [Frame]
     c_lib.chfl_cell_from_frame.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_copy", at cell.h:82:13
+    # Function "chfl_cell_copy", at cell.h:82
     c_lib.chfl_cell_copy.argtypes = [UnitCell]
     c_lib.chfl_cell_copy.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_volume", at cell.h:89:14
+    # Function "chfl_cell_volume", at cell.h:89
     c_lib.chfl_cell_volume.argtypes = [UnitCell, POINTER(c_double)]
     c_lib.chfl_cell_volume.restype = chfl_status
     c_lib.chfl_cell_volume.errcheck = _check_return_code
 
-    # Function "chfl_cell_lengths", at cell.h:98:14
+    # Function "chfl_cell_lengths", at cell.h:98
     c_lib.chfl_cell_lengths.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_lengths.restype = chfl_status
     c_lib.chfl_cell_lengths.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_lengths", at cell.h:109:14
+    # Function "chfl_cell_set_lengths", at cell.h:109
     c_lib.chfl_cell_set_lengths.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_set_lengths.restype = chfl_status
     c_lib.chfl_cell_set_lengths.errcheck = _check_return_code
 
-    # Function "chfl_cell_angles", at cell.h:118:14
+    # Function "chfl_cell_angles", at cell.h:118
     c_lib.chfl_cell_angles.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_angles.restype = chfl_status
     c_lib.chfl_cell_angles.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_angles", at cell.h:131:14
+    # Function "chfl_cell_set_angles", at cell.h:131
     c_lib.chfl_cell_set_angles.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_set_angles.restype = chfl_status
     c_lib.chfl_cell_set_angles.errcheck = _check_return_code
 
-    # Function "chfl_cell_matrix", at cell.h:149:14
+    # Function "chfl_cell_matrix", at cell.h:149
     c_lib.chfl_cell_matrix.argtypes = [UnitCell, ARRAY(chfl_vector3d, (3))]
     c_lib.chfl_cell_matrix.restype = chfl_status
     c_lib.chfl_cell_matrix.errcheck = _check_return_code
 
-    # Function "chfl_cell_shape", at cell.h:158:14
+    # Function "chfl_cell_shape", at cell.h:158
     c_lib.chfl_cell_shape.argtypes = [UnitCell, POINTER(chfl_cellshape)]
     c_lib.chfl_cell_shape.restype = chfl_status
     c_lib.chfl_cell_shape.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_shape", at cell.h:167:14
+    # Function "chfl_cell_set_shape", at cell.h:167
     c_lib.chfl_cell_set_shape.argtypes = [UnitCell, chfl_cellshape]
     c_lib.chfl_cell_set_shape.restype = chfl_status
     c_lib.chfl_cell_set_shape.errcheck = _check_return_code
 
-    # Function "chfl_cell_wrap", at cell.h:176:14
+    # Function "chfl_cell_wrap", at cell.h:176
     c_lib.chfl_cell_wrap.argtypes = [UnitCell, chfl_vector3d]
     c_lib.chfl_cell_wrap.restype = chfl_status
     c_lib.chfl_cell_wrap.errcheck = _check_return_code
 
-    # Function "chfl_frame", at frame.h:20:14
+    # Function "chfl_frame", at frame.h:20
     c_lib.chfl_frame.argtypes = []
     c_lib.chfl_frame.restype = POINTER(CHFL_FRAME)
 
-    # Function "chfl_frame_copy", at frame.h:30:14
+    # Function "chfl_frame_copy", at frame.h:30
     c_lib.chfl_frame_copy.argtypes = [Frame]
     c_lib.chfl_frame_copy.restype = POINTER(CHFL_FRAME)
 
-    # Function "chfl_frame_atoms_count", at frame.h:38:14
+    # Function "chfl_frame_atoms_count", at frame.h:38
     c_lib.chfl_frame_atoms_count.argtypes = [Frame, POINTER(c_uint64)]
     c_lib.chfl_frame_atoms_count.restype = chfl_status
     c_lib.chfl_frame_atoms_count.errcheck = _check_return_code
 
-    # Function "chfl_frame_positions", at frame.h:57:14
+    # Function "chfl_frame_positions", at frame.h:57
     c_lib.chfl_frame_positions.argtypes = [Frame, POINTER(POINTER(chfl_vector3d)), POINTER(c_uint64)]
     c_lib.chfl_frame_positions.restype = chfl_status
     c_lib.chfl_frame_positions.errcheck = _check_return_code
 
-    # Function "chfl_frame_velocities", at frame.h:80:14
+    # Function "chfl_frame_velocities", at frame.h:80
     c_lib.chfl_frame_velocities.argtypes = [Frame, POINTER(POINTER(chfl_vector3d)), POINTER(c_uint64)]
     c_lib.chfl_frame_velocities.restype = chfl_status
     c_lib.chfl_frame_velocities.errcheck = _check_return_code
 
-    # Function "chfl_frame_add_atom", at frame.h:92:14
+    # Function "chfl_frame_add_atom", at frame.h:92
     c_lib.chfl_frame_add_atom.argtypes = [Frame, Atom, chfl_vector3d, chfl_vector3d]
     c_lib.chfl_frame_add_atom.restype = chfl_status
     c_lib.chfl_frame_add_atom.errcheck = _check_return_code
 
-    # Function "chfl_frame_remove", at frame.h:105:14
+    # Function "chfl_frame_remove", at frame.h:105
     c_lib.chfl_frame_remove.argtypes = [Frame, c_uint64]
     c_lib.chfl_frame_remove.restype = chfl_status
     c_lib.chfl_frame_remove.errcheck = _check_return_code
 
-    # Function "chfl_frame_resize", at frame.h:117:14
+    # Function "chfl_frame_resize", at frame.h:117
     c_lib.chfl_frame_resize.argtypes = [Frame, c_uint64]
     c_lib.chfl_frame_resize.restype = chfl_status
     c_lib.chfl_frame_resize.errcheck = _check_return_code
 
-    # Function "chfl_frame_add_velocities", at frame.h:129:14
+    # Function "chfl_frame_add_velocities", at frame.h:129
     c_lib.chfl_frame_add_velocities.argtypes = [Frame]
     c_lib.chfl_frame_add_velocities.restype = chfl_status
     c_lib.chfl_frame_add_velocities.errcheck = _check_return_code
 
-    # Function "chfl_frame_has_velocities", at frame.h:137:14
+    # Function "chfl_frame_has_velocities", at frame.h:137
     c_lib.chfl_frame_has_velocities.argtypes = [Frame, POINTER(c_bool)]
     c_lib.chfl_frame_has_velocities.restype = chfl_status
     c_lib.chfl_frame_has_velocities.errcheck = _check_return_code
 
-    # Function "chfl_frame_set_cell", at frame.h:146:14
+    # Function "chfl_frame_set_cell", at frame.h:146
     c_lib.chfl_frame_set_cell.argtypes = [Frame, UnitCell]
     c_lib.chfl_frame_set_cell.restype = chfl_status
     c_lib.chfl_frame_set_cell.errcheck = _check_return_code
 
-    # Function "chfl_frame_set_topology", at frame.h:158:14
+    # Function "chfl_frame_set_topology", at frame.h:158
     c_lib.chfl_frame_set_topology.argtypes = [Frame, Topology]
     c_lib.chfl_frame_set_topology.restype = chfl_status
     c_lib.chfl_frame_set_topology.errcheck = _check_return_code
 
-    # Function "chfl_frame_step", at frame.h:168:14
+    # Function "chfl_frame_step", at frame.h:168
     c_lib.chfl_frame_step.argtypes = [Frame, POINTER(c_uint64)]
     c_lib.chfl_frame_step.restype = chfl_status
     c_lib.chfl_frame_step.errcheck = _check_return_code
 
-    # Function "chfl_frame_set_step", at frame.h:177:14
+    # Function "chfl_frame_set_step", at frame.h:177
     c_lib.chfl_frame_set_step.argtypes = [Frame, c_uint64]
     c_lib.chfl_frame_set_step.restype = chfl_status
     c_lib.chfl_frame_set_step.errcheck = _check_return_code
 
-    # Function "chfl_frame_guess_bonds", at frame.h:189:14
+    # Function "chfl_frame_guess_bonds", at frame.h:189
     c_lib.chfl_frame_guess_bonds.argtypes = [Frame]
     c_lib.chfl_frame_guess_bonds.restype = chfl_status
     c_lib.chfl_frame_guess_bonds.errcheck = _check_return_code
 
-    # Function "chfl_frame_distance", at frame.h:198:14
+    # Function "chfl_frame_distance", at frame.h:198
     c_lib.chfl_frame_distance.argtypes = [Frame, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_distance.restype = chfl_status
     c_lib.chfl_frame_distance.errcheck = _check_return_code
 
-    # Function "chfl_frame_angle", at frame.h:209:14
+    # Function "chfl_frame_angle", at frame.h:209
     c_lib.chfl_frame_angle.argtypes = [Frame, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_angle.restype = chfl_status
     c_lib.chfl_frame_angle.errcheck = _check_return_code
 
-    # Function "chfl_frame_dihedral", at frame.h:220:14
+    # Function "chfl_frame_dihedral", at frame.h:220
     c_lib.chfl_frame_dihedral.argtypes = [Frame, c_uint64, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_dihedral.restype = chfl_status
     c_lib.chfl_frame_dihedral.errcheck = _check_return_code
 
-    # Function "chfl_frame_out_of_plane", at frame.h:234:14
+    # Function "chfl_frame_out_of_plane", at frame.h:234
     c_lib.chfl_frame_out_of_plane.argtypes = [Frame, c_uint64, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_out_of_plane.restype = chfl_status
     c_lib.chfl_frame_out_of_plane.errcheck = _check_return_code
 
-    # Function "chfl_frame_properties_count", at frame.h:243:14
+    # Function "chfl_frame_properties_count", at frame.h:243
     c_lib.chfl_frame_properties_count.argtypes = [Frame, POINTER(c_uint64)]
     c_lib.chfl_frame_properties_count.restype = chfl_status
     c_lib.chfl_frame_properties_count.errcheck = _check_return_code
 
-    # Function "chfl_frame_list_properties", at frame.h:259:14
-    c_lib.chfl_frame_list_properties.argtypes = [Frame, ndpointer(c_char, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    # Function "chfl_frame_list_properties", at frame.h:259
+    c_lib.chfl_frame_list_properties.argtypes = [Frame, POINTER(c_char_p), c_uint64]
     c_lib.chfl_frame_list_properties.restype = chfl_status
     c_lib.chfl_frame_list_properties.errcheck = _check_return_code
 
-    # Function "chfl_frame_set_property", at frame.h:271:14
+    # Function "chfl_frame_set_property", at frame.h:271
     c_lib.chfl_frame_set_property.argtypes = [Frame, c_char_p, Property]
     c_lib.chfl_frame_set_property.restype = chfl_status
     c_lib.chfl_frame_set_property.errcheck = _check_return_code
 
-    # Function "chfl_frame_get_property", at frame.h:285:17
+    # Function "chfl_frame_get_property", at frame.h:285
     c_lib.chfl_frame_get_property.argtypes = [Frame, c_char_p]
     c_lib.chfl_frame_get_property.restype = POINTER(CHFL_PROPERTY)
 
-    # Function "chfl_frame_add_bond", at frame.h:294:14
+    # Function "chfl_frame_add_bond", at frame.h:294
     c_lib.chfl_frame_add_bond.argtypes = [Frame, c_uint64, c_uint64]
     c_lib.chfl_frame_add_bond.restype = chfl_status
     c_lib.chfl_frame_add_bond.errcheck = _check_return_code
 
-    # Function "chfl_frame_bond_with_order", at frame.h:304:14
+    # Function "chfl_frame_bond_with_order", at frame.h:304
     c_lib.chfl_frame_bond_with_order.argtypes = [Frame, c_uint64, c_uint64, chfl_bond_order]
     c_lib.chfl_frame_bond_with_order.restype = chfl_status
     c_lib.chfl_frame_bond_with_order.errcheck = _check_return_code
 
-    # Function "chfl_frame_remove_bond", at frame.h:316:14
+    # Function "chfl_frame_remove_bond", at frame.h:316
     c_lib.chfl_frame_remove_bond.argtypes = [Frame, c_uint64, c_uint64]
     c_lib.chfl_frame_remove_bond.restype = chfl_status
     c_lib.chfl_frame_remove_bond.errcheck = _check_return_code
 
-    # Function "chfl_frame_add_residue", at frame.h:328:14
+    # Function "chfl_frame_add_residue", at frame.h:328
     c_lib.chfl_frame_add_residue.argtypes = [Frame, Residue]
     c_lib.chfl_frame_add_residue.restype = chfl_status
     c_lib.chfl_frame_add_residue.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_open", at trajectory.h:22:19
+    # Function "chfl_trajectory_open", at trajectory.h:22
     c_lib.chfl_trajectory_open.argtypes = [c_char_p, c_char]
     c_lib.chfl_trajectory_open.restype = POINTER(CHFL_TRAJECTORY)
 
-    # Function "chfl_trajectory_with_format", at trajectory.h:39:19
+    # Function "chfl_trajectory_with_format", at trajectory.h:39
     c_lib.chfl_trajectory_with_format.argtypes = [c_char_p, c_char, c_char_p]
     c_lib.chfl_trajectory_with_format.restype = POINTER(CHFL_TRAJECTORY)
 
-    # Function "chfl_trajectory_path", at trajectory.h:52:14
-    c_lib.chfl_trajectory_path.argtypes = [Trajectory, POINTER(POINTER(c_char))]
+    # Function "chfl_trajectory_path", at trajectory.h:52
+    c_lib.chfl_trajectory_path.argtypes = [Trajectory, POINTER(c_char_p)]
     c_lib.chfl_trajectory_path.restype = chfl_status
     c_lib.chfl_trajectory_path.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_read", at trajectory.h:64:14
+    # Function "chfl_trajectory_read", at trajectory.h:64
     c_lib.chfl_trajectory_read.argtypes = [Trajectory, Frame]
     c_lib.chfl_trajectory_read.restype = chfl_status
     c_lib.chfl_trajectory_read.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_read_step", at trajectory.h:76:14
+    # Function "chfl_trajectory_read_step", at trajectory.h:76
     c_lib.chfl_trajectory_read_step.argtypes = [Trajectory, c_uint64, Frame]
     c_lib.chfl_trajectory_read_step.restype = chfl_status
     c_lib.chfl_trajectory_read_step.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_write", at trajectory.h:85:14
+    # Function "chfl_trajectory_write", at trajectory.h:85
     c_lib.chfl_trajectory_write.argtypes = [Trajectory, Frame]
     c_lib.chfl_trajectory_write.restype = chfl_status
     c_lib.chfl_trajectory_write.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_set_topology", at trajectory.h:96:14
+    # Function "chfl_trajectory_set_topology", at trajectory.h:96
     c_lib.chfl_trajectory_set_topology.argtypes = [Trajectory, Topology]
     c_lib.chfl_trajectory_set_topology.restype = chfl_status
     c_lib.chfl_trajectory_set_topology.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_topology_file", at trajectory.h:110:14
+    # Function "chfl_trajectory_topology_file", at trajectory.h:110
     c_lib.chfl_trajectory_topology_file.argtypes = [Trajectory, c_char_p, c_char_p]
     c_lib.chfl_trajectory_topology_file.restype = chfl_status
     c_lib.chfl_trajectory_topology_file.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_set_cell", at trajectory.h:120:14
+    # Function "chfl_trajectory_set_cell", at trajectory.h:120
     c_lib.chfl_trajectory_set_cell.argtypes = [Trajectory, UnitCell]
     c_lib.chfl_trajectory_set_cell.restype = chfl_status
     c_lib.chfl_trajectory_set_cell.errcheck = _check_return_code
 
-    # Function "chfl_trajectory_nsteps", at trajectory.h:130:14
+    # Function "chfl_trajectory_nsteps", at trajectory.h:130
     c_lib.chfl_trajectory_nsteps.argtypes = [Trajectory, POINTER(c_uint64)]
     c_lib.chfl_trajectory_nsteps.restype = chfl_status
     c_lib.chfl_trajectory_nsteps.errcheck = _check_return_code
 
-    # Function "chfl_selection", at selection.h:20:18
+    # Function "chfl_selection", at selection.h:20
     c_lib.chfl_selection.argtypes = [c_char_p]
     c_lib.chfl_selection.restype = POINTER(CHFL_SELECTION)
 
-    # Function "chfl_selection_copy", at selection.h:33:18
+    # Function "chfl_selection_copy", at selection.h:33
     c_lib.chfl_selection_copy.argtypes = [Selection]
     c_lib.chfl_selection_copy.restype = POINTER(CHFL_SELECTION)
 
-    # Function "chfl_selection_size", at selection.h:45:14
+    # Function "chfl_selection_size", at selection.h:45
     c_lib.chfl_selection_size.argtypes = [Selection, POINTER(c_uint64)]
     c_lib.chfl_selection_size.restype = chfl_status
     c_lib.chfl_selection_size.errcheck = _check_return_code
 
-    # Function "chfl_selection_string", at selection.h:58:14
+    # Function "chfl_selection_string", at selection.h:58
     c_lib.chfl_selection_string.argtypes = [Selection, c_char_p, c_uint64]
     c_lib.chfl_selection_string.restype = chfl_status
     c_lib.chfl_selection_string.errcheck = _check_return_code
 
-    # Function "chfl_selection_evaluate", at selection.h:71:14
+    # Function "chfl_selection_evaluate", at selection.h:71
     c_lib.chfl_selection_evaluate.argtypes = [Selection, Frame, POINTER(c_uint64)]
     c_lib.chfl_selection_evaluate.restype = chfl_status
     c_lib.chfl_selection_evaluate.errcheck = _check_return_code
 
-    # Function "chfl_selection_matches", at selection.h:97:14
+    # Function "chfl_selection_matches", at selection.h:97
     c_lib.chfl_selection_matches.argtypes = [Selection, ndpointer(chfl_match, flags="C_CONTIGUOUS", ndim=1), c_uint64]
     c_lib.chfl_selection_matches.restype = chfl_status
     c_lib.chfl_selection_matches.errcheck = _check_return_code

--- a/chemfiles/frame.py
+++ b/chemfiles/frame.py
@@ -24,7 +24,7 @@ class Frame(CxxPointer):
         Create an empty :py:class:`Frame` that will be resized by the runtime
         as needed.
         """
-        super(Frame, self).__init__(self.ffi.chfl_frame())
+        super(Frame, self).__init__(self.ffi.chfl_frame(), is_const=False)
 
     def __copy__(self):
         return Frame.from_ptr(self.ffi.chfl_frame_copy(self))
@@ -173,7 +173,11 @@ class Frame(CxxPointer):
         return velocities.value
 
     def cell(self):
-        """Get a copy of the :py:class:`UnitCell` of this :py:class:`Frame`."""
+        """
+        Get a mutable reference to the :py:class:`UnitCell` of this
+        :py:class:`Frame`. Any modification to the cell will be reflected in
+        the frame.
+        """
         return UnitCell.from_ptr(self.ffi.chfl_cell_from_frame(self))
 
     def set_cell(self, cell):
@@ -184,9 +188,10 @@ class Frame(CxxPointer):
 
     def topology(self):
         """
-        Get a copy of the :py:class:`Topology` of this :py:class:`Frame`.
+        Get read-only access to the :py:class:`Topology` of this
+        :py:class:`Frame`.
         """
-        return Topology.from_ptr(self.ffi.chfl_topology_from_frame(self))
+        return Topology.from_const_ptr(self.ffi.chfl_topology_from_frame(self))
 
     def set_topology(self, topology):
         """

--- a/chemfiles/frame.py
+++ b/chemfiles/frame.py
@@ -12,246 +12,236 @@ from .property import Property
 
 
 class Frame(CxxPointer):
-    '''
+    """
     A :py:class:`Frame` contains data from one simulation step: the current
     unit cell, the topology, the positions, and the velocities of the particles
     in the system. If some information is missing (topology or velocity or unit
     cell), the corresponding data is filled with a default value.
-    '''
+    """
 
     def __init__(self):
-        '''
+        """
         Create an empty :py:class:`Frame` that will be resized by the runtime
         as needed.
-        '''
+        """
         super(Frame, self).__init__(self.ffi.chfl_frame())
-
-    def __del__(self):
-        if hasattr(self, 'ptr'):
-            self.ffi.chfl_frame_free(self)
 
     def __copy__(self):
         return Frame.from_ptr(self.ffi.chfl_frame_copy(self))
 
     def __iter__(self):
-        for i in range(self.natoms()):
+        for i in range(self.atoms_count()):
             yield self.atom(i)
 
     def atom(self, i):
-        '''
+        """
         Get a copy of the :py:class:`Atom` at index ``i`` in this
         :py:class:`Frame`.
-        '''
-        if i >= self.natoms():
-            raise IndexError(
-                "atom index ({}) out of range for this frame".format(i)
-            )
+        """
+        if i >= self.atoms_count():
+            raise IndexError("atom index ({}) out of range for this frame".format(i))
         return Atom.from_ptr(self.ffi.chfl_atom_from_frame(self, c_uint64(i)))
 
-    def natoms(self):
-        '''Get the current number of atoms in this :py:class:`Frame`.'''
-        natoms = c_uint64()
-        self.ffi.chfl_frame_atoms_count(self, natoms)
-        return natoms.value
+    def atoms_count(self):
+        """Get the current number of atoms in this :py:class:`Frame`."""
+        count = c_uint64()
+        self.ffi.chfl_frame_atoms_count(self, count)
+        return count.value
 
     def __len__(self):
-        '''Get the current number of atoms in this :py:class:`Frame`.'''
-        return self.natoms()
+        """Get the current number of atoms in this :py:class:`Frame`."""
+        return self.atoms_count()
 
-    def resize(self, natoms):
-        '''
-        Resize the positions, velocities  and topology in this
-        :py:class:`Frame`, to have space for `natoms` atoms.
+    def resize(self, count):
+        """
+        Resize the positions, velocities and topology in this
+        :py:class:`Frame`, to have space for `count` atoms.
 
         This function may invalidate any array of the positions or the
         velocities if the new size is bigger than the old one. In all cases,
         previous data is conserved. This function conserve the presence or
         absence of velocities.
-        '''
-        self.ffi.chfl_frame_resize(self, c_uint64(natoms))
+        """
+        self.ffi.chfl_frame_resize(self, c_uint64(count))
 
     def add_atom(self, atom, position, velocity=None):
-        '''
+        """
         Add a copy of the :py:class:`Atom` ``atom`` and the corresponding
         ``position`` and ``velocity`` to this :py:class:`Frame`.
 
         ``velocity`` can be ``None`` if no velocity is associated with the
         atom.
-        '''
+        """
         position = chfl_vector3d(position[0], position[1], position[2])
         if velocity:
             velocity = chfl_vector3d(velocity[0], velocity[1], velocity[2])
         self.ffi.chfl_frame_add_atom(self, atom, position, velocity)
 
     def remove(self, i):
-        '''
+        """
         Remove the atom at index ``i`` in this :py:class:`Frame`.
 
         This modify all the atoms indexes after ``i``, and invalidate any array
         obtained using :py:func:`Frame.positions` or
         :py:func:`Frame.velocities`.
-        '''
+        """
         self.ffi.chfl_frame_remove(self, c_uint64(i))
 
     def add_bond(self, i, j):
-        '''
+        """
         Add a bond between the atoms at indexes ``i`` and ``j`` in this
         :py:class:`Frame`'s topology.
-        '''
+        """
         self.ffi.chfl_frame_add_bond(self, c_uint64(i), c_uint64(j))
 
     def remove_bond(self, i, j):
-        '''
+        """
         Remove any existing bond between the atoms at indexes ``i`` and ``j``
         in this :py:class:`Frame`'s topology.
 
         This function does nothing if there is no bond between ``i`` and ``j``.
-        '''
+        """
         self.ffi.chfl_frame_remove_bond(self, c_uint64(i), c_uint64(j))
 
     def add_residue(self, residue):
-        '''
+        """
         Add the :py:class:`Residue` ``residue`` to this :py:class:`Frame`'s
         topology.
 
         The residue ``id`` must not already be in the topology, and the residue
         must contain only atoms that are not already in another residue.
-        '''
+        """
         self.ffi.chfl_frame_add_residue(self, residue)
 
     def positions(self):
-        '''
+        """
         Get a view into the positions of this :py:class:`Frame`.
 
-        Positions are stored as a `natoms x 3` array by thez runtime, this
-        function gives direct access to the corresponding memory as a numpy
-        array. Modifying the array will change the positions.
+        This function gives direct access to the positions as a numpy array.
+        Modifying the array will change the positions in the frame.
 
         If the frame is resized (by writing to it, calling
         :py:func:`Frame.resize`, :py:func:`Frame.add_atom`,
         :py:func:`Frame.remove`), the array is invalidated. Accessing it can
         cause a segfault.
-        '''
-        natoms = c_uint64()
+        """
+        count = c_uint64()
         data = POINTER(chfl_vector3d)()
-        self.ffi.chfl_frame_positions(self, data, natoms)
-        natoms = natoms.value
-        if natoms != 0:
-            positions = np.ctypeslib.as_array(data, shape=(natoms,))
-            return positions.view(np.float64).reshape((natoms, 3))
+        self.ffi.chfl_frame_positions(self, data, count)
+        count = count.value
+        if count != 0:
+            positions = np.ctypeslib.as_array(data, shape=(count,))
+            return positions.view(np.float64).reshape((count, 3))
         else:
             return np.array([[], [], []], dtype=np.float64)
 
     def velocities(self):
-        '''
+        """
         Get a view into the velocities of this :py:class:`Frame`.
 
-        Velocities are stored as a `natoms x 3` array by thez runtime, this
-        function gives direct access to the corresponding memory as a numpy
-        array. Modifying the array will change the velocities.
+        This function gives direct access to the velocities as a numpy array.
+        Modifying the array will change the velocities in the frame.
 
         If the frame is resized (by writing to it, calling
         :py:func:`Frame.resize`, :py:func:`Frame.add_atom`,
         :py:func:`Frame.remove`), the array is invalidated. Accessing it can
         cause a segfault.
-        '''
-        natoms = c_uint64()
+        """
+        count = c_uint64()
         data = POINTER(chfl_vector3d)()
-        self.ffi.chfl_frame_velocities(self, data, natoms)
-        natoms = natoms.value
-        if natoms != 0:
-            positions = np.ctypeslib.as_array(data, shape=(natoms,))
-            return positions.view(np.float64).reshape((natoms, 3))
+        self.ffi.chfl_frame_velocities(self, data, count)
+        count = count.value
+        if count != 0:
+            positions = np.ctypeslib.as_array(data, shape=(count,))
+            return positions.view(np.float64).reshape((count, 3))
         else:
             return np.array([[], [], []], dtype=np.float64)
 
     def add_velocities(self):
-        '''
+        """
         Add velocity data to this :py:class:`Frame`.
 
         The velocities are initialized to zero. If the frame already contains
         velocities, this function does nothing.
-        '''
+        """
         self.ffi.chfl_frame_add_velocities(self)
 
     def has_velocities(self):
-        '''Check if this :py:class:`Frame` contains velocity.'''
+        """Check if this :py:class:`Frame` contains velocity."""
         velocities = c_bool()
         self.ffi.chfl_frame_has_velocities(self, velocities)
         return velocities.value
 
     def cell(self):
-        '''Get a copy of the :py:class:`UnitCell` of this :py:class:`Frame`.'''
+        """Get a copy of the :py:class:`UnitCell` of this :py:class:`Frame`."""
         return UnitCell.from_ptr(self.ffi.chfl_cell_from_frame(self))
 
     def set_cell(self, cell):
-        '''
+        """
         Set the :py:class:`UnitCell` of this :py:class:`Frame` to ``cell``.
-        '''
+        """
         self.ffi.chfl_frame_set_cell(self, cell)
 
     def topology(self):
-        '''
+        """
         Get a copy of the :py:class:`Topology` of this :py:class:`Frame`.
-        '''
+        """
         return Topology.from_ptr(self.ffi.chfl_topology_from_frame(self))
 
     def set_topology(self, topology):
-        '''
+        """
         Set the :py:class:`Topology` of this :py:class:`Frame` to ``topology``.
-        '''
+        """
         self.ffi.chfl_frame_set_topology(self, topology)
 
     def step(self):
-        '''
+        """
         Get this :py:class:`Frame` step, i.e. the frame number in the
         trajectory.
-        '''
+        """
         step = c_uint64()
         self.ffi.chfl_frame_step(self, step)
         return step.value
 
     def set_step(self, step):
-        '''Set this :py:class:`Frame` step to ``step``.'''
+        """Set this :py:class:`Frame` step to ``step``."""
         self.ffi.chfl_frame_set_step(self, c_uint64(step))
 
-    def guess_topology(self):
-        '''
+    def guess_bonds(self):
+        """
         Guess the bonds, angles and dihedrals in this :py:class:`Frame`.
 
         The bonds are guessed using a distance-based algorithm, and then angles
         and dihedrals are guessed from the bonds.
-        '''
-        self.ffi.chfl_frame_guess_topology(self)
+        """
+        self.ffi.chfl_frame_guess_bonds(self)
 
     def distance(self, i, j):
-        '''
+        """
         Get the distance between the atoms at indexes ``i`` and ``j`` in this
         :py:class:`Frame`, accounting for periodic boundary conditions. The
         result is expressed in angstroms.
-        '''
+        """
         distance = c_double()
         self.ffi.chfl_frame_distance(self, c_uint64(i), c_uint64(j), distance)
         return distance.value
 
     def angle(self, i, j, k):
-        '''
+        """
         Get the angle formed by the atoms at indexes ``i``, ``j`` and ``k`` in
         this :py:class:`Frame`, accounting for periodic boundary conditions.
         The result is expressed in radians.
-        '''
+        """
         angle = c_double()
-        self.ffi.chfl_frame_angle(
-            self, c_uint64(i), c_uint64(j), c_uint64(k), angle
-        )
+        self.ffi.chfl_frame_angle(self, c_uint64(i), c_uint64(j), c_uint64(k), angle)
         return angle.value
 
     def dihedral(self, i, j, k, m):
-        '''
+        """
         Get the dihedral angle formed by the atoms at indexes ``i``, ``j``,
         ``k`` and ``m`` in this :py:class:`Frame`, accounting for periodic
         boundary conditions. The result is expressed in radians.
-        '''
+        """
         dihedral = c_double()
         self.ffi.chfl_frame_dihedral(
             self, c_uint64(i), c_uint64(j), c_uint64(k), c_uint64(m), dihedral
@@ -259,14 +249,14 @@ class Frame(CxxPointer):
         return dihedral.value
 
     def out_of_plane(self, i, j, k, m):
-        '''
+        """
         Get the out of plane distance formed by the atoms at indexes ``i``,
         ``j``, ``k`` and ``m`` in this :py:class:`Frame`, accounting for
         periodic boundary conditions. The result is expressed in angstroms.
 
         This is the distance betweent the atom j and the ikm plane. The j atom
         is the center of the improper dihedral angle formed by i, j, k and m.
-        '''
+        """
         distance = c_double()
         self.ffi.chfl_frame_out_of_plane(
             self, c_uint64(i), c_uint64(j), c_uint64(k), c_uint64(m), distance
@@ -274,18 +264,16 @@ class Frame(CxxPointer):
         return distance.value
 
     def set(self, name, value):
-        '''
+        """
         Set a property of this frame, with the given ``name`` and ``value``.
         The new value overwrite any pre-existing property with the same name.
-        '''
-        self.ffi.chfl_frame_set_property(
-            self, name.encode("utf8"), Property(value)
-        )
+        """
+        self.ffi.chfl_frame_set_property(self, name.encode("utf8"), Property(value))
 
     def get(self, name):
-        '''
+        """
         Get a property of this frame with the given ``name``, or raise an error
         if the property does not exists.
-        '''
+        """
         ptr = self.ffi.chfl_frame_get_property(self, name.encode("utf8"))
         return Property.from_ptr(ptr).get()

--- a/chemfiles/misc.py
+++ b/chemfiles/misc.py
@@ -1,0 +1,77 @@
+# -*- coding=utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+import warnings
+
+from .clib import _get_c_library
+
+
+class ChemfilesWarning(UserWarning):
+    """Warnings from the Chemfiles runtime."""
+
+    pass
+
+
+class ChemfilesError(BaseException):
+    """Exception class for errors in chemfiles"""
+
+    pass
+
+
+# Store a reference to the last logging callback, to preven Python from
+# garbage-collecting it.
+_CURRENT_CALLBACK = None
+
+
+def set_warnings_callback(function):
+    """
+    Call `function` on every warning event. The callback should take a string
+    message and return nothing.
+
+    By default, warnings are send to python `warnings` module.
+    """
+    from .ffi import chfl_warning_callback
+
+    def callback(message):
+        try:
+            function(message.decode("utf8"))
+        except Exception as e:
+            message = "exception raised in warning callback: {}".format(e)
+            warnings.warn(message, ChemfilesWarning)
+
+    global _CURRENT_CALLBACK
+    _CURRENT_CALLBACK = chfl_warning_callback(callback)
+
+    _get_c_library().chfl_set_warning_callback(_CURRENT_CALLBACK)
+
+
+def add_configuration(path):
+    """
+    Read configuration data from the file at ``path``.
+
+    By default, chemfiles reads configuration from any file name `.chemfilesrc`
+    in the current directory or any parent directory. This function can be used
+    to add data from another configuration file.
+
+    This function will fail if there is no file at ``path``, or if the file is
+    incorectly formatted. Data from the new configuration file will overwrite
+    any existing data.
+    """
+    _get_c_library().chfl_add_configuration(path.encode("utf8"))
+
+
+def _last_error():
+    """Get the last error from the chemfiles runtime."""
+    return _get_c_library().chfl_last_error().decode("utf8")
+
+
+def _clear_errors():
+    """Clear any error message saved in the chemfiles runtime."""
+    return _get_c_library().chfl_clear_errors()
+
+
+def _set_default_warning_callback():
+    set_warnings_callback(
+        # We need to set stacklevel=4 to get through the lambda =>
+        # adapatator => C++ code => Python binding => user code
+        lambda message: warnings.warn(message, ChemfilesWarning, stacklevel=4)
+    )

--- a/chemfiles/property.py
+++ b/chemfiles/property.py
@@ -10,16 +10,16 @@ from .utils import ChemfilesError
 
 
 class Property(CxxPointer):
-    '''
+    """
     A :py:class:`Property` holds the data used in properties in
     :py:class:`Frame` and :py:class:`Atom`. A property can have various types:
     bool, double, string or 3D vectors.
 
     This class is not meant for direct use, but is an internal class.
-    '''
+    """
 
     def __init__(self, value):
-        '''Create a new property containing the given value'''
+        """Create a new property containing the given value"""
         if isinstance(value, bool):
             ptr = self.ffi.chfl_property_bool(c_bool(value))
         elif isinstance(value, (float, int)):
@@ -30,15 +30,9 @@ class Property(CxxPointer):
             value = chfl_vector3d(value[0], value[1], value[2])
             ptr = self.ffi.chfl_property_vector3d(value)
         else:
-            raise ChemfilesError(
-                "can not create a Property with this value"
-            )
+            raise ChemfilesError("can not create a Property with this value")
 
         super(Property, self).__init__(ptr)
-
-    def __del__(self):
-        if hasattr(self, 'ptr'):
-            self.ffi.chfl_property_free(self)
 
     def get(self):
         kind = chfl_property_kind()
@@ -52,8 +46,10 @@ class Property(CxxPointer):
             self.ffi.chfl_property_get_double(self, value)
             return value.value
         if kind.value == chfl_property_kind.CHFL_PROPERTY_STRING:
+
             def callback(buffer, size):
                 self.ffi.chfl_property_get_string(self, buffer, size)
+
             return _call_with_growing_buffer(callback, initial=32)
         if kind.value == chfl_property_kind.CHFL_PROPERTY_VECTOR3D:
             value = chfl_vector3d()

--- a/chemfiles/property.py
+++ b/chemfiles/property.py
@@ -32,7 +32,7 @@ class Property(CxxPointer):
         else:
             raise ChemfilesError("can not create a Property with this value")
 
-        super(Property, self).__init__(ptr)
+        super(Property, self).__init__(ptr, is_const=False)
 
     def get(self):
         kind = chfl_property_kind()

--- a/chemfiles/property.py
+++ b/chemfiles/property.py
@@ -5,8 +5,8 @@ import numpy as np
 from ctypes import c_double, c_bool
 
 from .ffi import chfl_property_kind, chfl_vector3d
-from .utils import CxxPointer, _call_with_growing_buffer
-from .utils import ChemfilesError
+from .misc import ChemfilesError
+from ._utils import CxxPointer, _call_with_growing_buffer, string_type
 
 
 class Property(CxxPointer):
@@ -24,13 +24,15 @@ class Property(CxxPointer):
             ptr = self.ffi.chfl_property_bool(c_bool(value))
         elif isinstance(value, (float, int)):
             ptr = self.ffi.chfl_property_double(c_double(value))
-        elif _is_string(value):
+        elif isinstance(value, string_type):
             ptr = self.ffi.chfl_property_string(value.encode("utf8"))
         elif _is_vector3d(value):
             value = chfl_vector3d(value[0], value[1], value[2])
             ptr = self.ffi.chfl_property_vector3d(value)
         else:
-            raise ChemfilesError("can not create a Property with this value")
+            raise ChemfilesError(
+                "can not create a Property with a value of type '{}'".format(type(value))
+            )
 
         super(Property, self).__init__(ptr, is_const=False)
 
@@ -57,13 +59,6 @@ class Property(CxxPointer):
             return value[0], value[1], value[2]
         else:
             raise ChemfilesError("unknown property kind, this is a bug")
-
-
-def _is_string(value):
-    if sys.version_info[0] == 3:
-        return isinstance(value, str)
-    else:
-        return isinstance(value, basestring)
 
 
 def _is_vector3d(value):

--- a/chemfiles/residue.py
+++ b/chemfiles/residue.py
@@ -4,6 +4,7 @@ from ctypes import c_bool, c_uint64, c_char_p
 import numpy as np
 
 from ._utils import CxxPointer, _call_with_growing_buffer, string_type
+from .misc import ChemfilesError
 from .property import Property
 
 
@@ -18,7 +19,7 @@ class ResidueAtoms(object):
     def __len__(self):
         """Get the current number of atoms in this :py:class:`Residue`."""
         if self.indexes is not None:
-            return len(indexes)
+            return len(self.indexes)
         else:
             count = c_uint64()
             self.residue.ffi.chfl_residue_atoms_count(self.residue, count)

--- a/chemfiles/residue.py
+++ b/chemfiles/residue.py
@@ -23,12 +23,10 @@ class Residue(CxxPointer):
             ptr = self.ffi.chfl_residue_with_id(name.encode("utf8"), c_uint64(resid))
         else:
             ptr = self.ffi.chfl_residue(name.encode("utf8"))
-        super(Residue, self).__init__(ptr)
+        super(Residue, self).__init__(ptr, is_const=False)
 
     def __copy__(self):
-        residue = self.__new__(Residue)
-        super(Residue, residue).__init__(self.ffi.chfl_residue_copy(self))
-        return residue
+        return Residue.from_ptr(self.ffi.chfl_residue_copy(self))
 
     def atoms_count(self):
         """Get the current number of atoms in the :py:class:`Residue`."""

--- a/chemfiles/residue.py
+++ b/chemfiles/residue.py
@@ -7,72 +7,65 @@ from .utils import CxxPointer, _call_with_growing_buffer
 
 
 class Residue(CxxPointer):
-    '''
+    """
     A :py:class:`Residue` is a group of atoms belonging to the same logical
     unit. They can be small molecules, amino-acids in a protein, monomers in
     polymers, etc.
-    '''
+    """
 
     def __init__(self, name, resid=None):
-        '''
+        """
         Create a new :py:class:`Residue` from a ``name`` and optionally a
         residue id ``resid``.
-        '''
+        """
 
         if resid:
-            ptr = self.ffi.chfl_residue_with_id(
-                name.encode("utf8"), c_uint64(resid)
-            )
+            ptr = self.ffi.chfl_residue_with_id(name.encode("utf8"), c_uint64(resid))
         else:
             ptr = self.ffi.chfl_residue(name.encode("utf8"))
         super(Residue, self).__init__(ptr)
-
-    def __del__(self):
-        if hasattr(self, 'ptr'):
-            self.ffi.chfl_residue_free(self)
 
     def __copy__(self):
         residue = self.__new__(Residue)
         super(Residue, residue).__init__(self.ffi.chfl_residue_copy(self))
         return residue
 
-    def natoms(self):
-        '''Get the current number of atoms in the :py:class:`Residue`.'''
-        natoms = c_uint64()
-        self.ffi.chfl_residue_atoms_count(self, natoms)
-        return natoms.value
+    def atoms_count(self):
+        """Get the current number of atoms in the :py:class:`Residue`."""
+        count = c_uint64()
+        self.ffi.chfl_residue_atoms_count(self, count)
+        return count.value
 
     def __len__(self):
-        '''Get the current number of atoms in this :py:class:`Residue`.'''
-        return self.natoms()
+        """Get the current number of atoms in this :py:class:`Residue`."""
+        return self.atoms_count()
 
     def name(self):
-        '''Get the name of this :py:class:`Residue`.'''
+        """Get the name of this :py:class:`Residue`."""
         return _call_with_growing_buffer(
-            lambda buff, size: self.ffi.chfl_residue_name(self, buff, size),
-            initial=32,
+            lambda buff, size: self.ffi.chfl_residue_name(self, buff, size), initial=32
         )
 
     def id(self):
-        '''Get the :py:class:`Residue` index in the initial topology.'''
+        """Get the :py:class:`Residue` index in the initial topology."""
         id = c_uint64()
         self.ffi.chfl_residue_id(self, id)
         return id.value
 
     def contains(self, atom):
-        '''
+        """
         Check if the :py:class:`Residue` contains the atom at index ``atom``.
-        '''
+        """
         contained = c_bool()
         self.ffi.chfl_residue_contains(self, c_uint64(atom), contained)
         return contained.value
 
     def add_atom(self, atom):
-        '''Add the atom index ``atom`` in the :py:class:`Residue`.'''
+        """Add the atom index ``atom`` in the :py:class:`Residue`."""
         self.ffi.chfl_residue_add_atom(self, c_uint64(atom))
 
     def atoms(self):
-        '''Get the indexes of the atoms in this :py:class:`Residue`.'''
+        """Get the indexes of the atoms in this :py:class:`Residue`."""
         n = len(self)
         atoms = np.zeros(n, np.uint64)
         self.ffi.chfl_residue_atoms(self, atoms, c_uint64(n))

--- a/chemfiles/residue.py
+++ b/chemfiles/residue.py
@@ -3,7 +3,57 @@ from __future__ import absolute_import, print_function, unicode_literals
 from ctypes import c_bool, c_uint64
 import numpy as np
 
-from .utils import CxxPointer, _call_with_growing_buffer
+from ._utils import CxxPointer, _call_with_growing_buffer
+
+
+class ResidueAtoms(object):
+    """Proxy object to get the atomic indexes in a residue"""
+
+    def __init__(self, residue):
+        self.residue = residue
+        # Use a cache for indexes
+        self.indexes = None
+
+    def __len__(self):
+        """Get the current number of atoms in this :py:class:`Residue`."""
+        if self.indexes is not None:
+            return len(indexes)
+        else:
+            count = c_uint64()
+            self.residue.ffi.chfl_residue_atoms_count(self.residue, count)
+            return count.value
+
+    def __contains__(self, index):
+        """
+        Check if the :py:class:`Residue` contains the atom at index ``atom``.
+        """
+        if self.indexes is not None:
+            return index in self.indexes
+        else:
+            result = c_bool()
+            self.residue.ffi.chfl_residue_contains(self.residue, c_uint64(index), result)
+            return result.value
+
+    def __getitem__(self, i):
+        """
+        Get the atomic index number ``i`` in the associated :py:class:`Residue`.
+        """
+        if self.indexes is None:
+            count = len(self)
+            self.indexes = np.zeros(count, np.uint64)
+            self.residue.ffi.chfl_residue_atoms(self.residue, self.indexes, c_uint64(count))
+
+        return self.indexes[i]
+
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]
+
+    def append(self, atom):
+        """Add the atom index ``atom`` in the :py:class:`Residue`."""
+        self.residue.ffi.chfl_residue_add_atom(self.residue, c_uint64(atom))
+        # reset the cache for indexes
+        self.indexes = None
 
 
 class Residue(CxxPointer):
@@ -28,43 +78,20 @@ class Residue(CxxPointer):
     def __copy__(self):
         return Residue.from_ptr(self.ffi.chfl_residue_copy(self))
 
-    def atoms_count(self):
-        """Get the current number of atoms in the :py:class:`Residue`."""
-        count = c_uint64()
-        self.ffi.chfl_residue_atoms_count(self, count)
-        return count.value
-
-    def __len__(self):
-        """Get the current number of atoms in this :py:class:`Residue`."""
-        return self.atoms_count()
-
+    @property
     def name(self):
         """Get the name of this :py:class:`Residue`."""
         return _call_with_growing_buffer(
             lambda buff, size: self.ffi.chfl_residue_name(self, buff, size), initial=32
         )
 
+    @property
     def id(self):
         """Get the :py:class:`Residue` index in the initial topology."""
         id = c_uint64()
         self.ffi.chfl_residue_id(self, id)
         return id.value
 
-    def contains(self, atom):
-        """
-        Check if the :py:class:`Residue` contains the atom at index ``atom``.
-        """
-        contained = c_bool()
-        self.ffi.chfl_residue_contains(self, c_uint64(atom), contained)
-        return contained.value
-
-    def add_atom(self, atom):
-        """Add the atom index ``atom`` in the :py:class:`Residue`."""
-        self.ffi.chfl_residue_add_atom(self, c_uint64(atom))
-
+    @property
     def atoms(self):
-        """Get the indexes of the atoms in this :py:class:`Residue`."""
-        n = len(self)
-        atoms = np.zeros(n, np.uint64)
-        self.ffi.chfl_residue_atoms(self, atoms, c_uint64(n))
-        return atoms
+        return ResidueAtoms(self)

--- a/chemfiles/selection.py
+++ b/chemfiles/selection.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from ctypes import c_uint64
 import numpy as np
 
-from .utils import CxxPointer, _call_with_growing_buffer
+from ._utils import CxxPointer, _call_with_growing_buffer
 from .ffi import chfl_match
 
 
@@ -31,6 +31,7 @@ class Selection(CxxPointer):
     def __copy__(self):
         return Selection.from_ptr(self.ffi.chfl_selection_copy(self))
 
+    @property
     def size(self):
         """
         Get the size of this :py:class:`Selection`.
@@ -44,6 +45,7 @@ class Selection(CxxPointer):
         self.ffi.chfl_selection_size(self, size)
         return size.value
 
+    @property
     def string(self):
         """
         Get the selection string used to create this :py:class:`Selection`.
@@ -64,7 +66,7 @@ class Selection(CxxPointer):
         matches = np.zeros(matching.value, chfl_match)
         self.ffi.chfl_selection_matches(self, matches, matching)
 
-        size = self.size()
+        size = self.size
         result = []
         for match in matches:
             assert match[0] == size

--- a/chemfiles/selection.py
+++ b/chemfiles/selection.py
@@ -9,7 +9,7 @@ from .ffi import chfl_match
 
 
 class Selection(CxxPointer):
-    '''
+    """
     Select atoms in a :py:class:`Frame` with a selection language.
 
     The selection language is built by combining basic operations. Each basic
@@ -19,50 +19,45 @@ class Selection(CxxPointer):
     <selections-doc>`_ to know the allowed selectors and how to use them.
 
     .. selections-doc: http://chemfiles.rtfd.io/en/latest/selections.html
-    '''
+    """
 
     def __init__(self, selection):
-        '''
+        """
         Create a new :py:class:`Selection` from the given ``selection`` string.
-        '''
+        """
         ptr = self.ffi.chfl_selection(selection.encode("utf8"))
         super(Selection, self).__init__(ptr)
-
-    def __del__(self):
-        if hasattr(self, 'ptr'):
-            self.ffi.chfl_selection_free(self)
 
     def __copy__(self):
         return Selection.from_ptr(self.ffi.chfl_selection_copy(self))
 
     def size(self):
-        '''
+        """
         Get the size of this :py:class:`Selection`.
 
         The size of a selection is the number of atoms we are selecting
         together. This value is 1 for the 'atom' context, 2 for the 'pair' and
         'bond' context, 3 for the 'three' and 'angles' contextes and 4 for the
         'four' and 'dihedral' contextes.
-        '''
+        """
         size = c_uint64()
         self.ffi.chfl_selection_size(self, size)
         return size.value
 
     def string(self):
-        '''
+        """
         Get the selection string used to create this :py:class:`Selection`.
-        '''
+        """
         return _call_with_growing_buffer(
-            lambda buff, n: self.ffi.chfl_selection_string(self, buff, n),
-            initial=128,
+            lambda buff, n: self.ffi.chfl_selection_string(self, buff, n), initial=128
         )
 
     def evaluate(self, frame):
-        '''
+        """
         Evaluate a :py:class:`Selection` for a given :py:class:`Frame`, and
         return a list of matching atoms, either as a list of index or a list
         of tuples of indexes.
-        '''
+        """
         matching = c_uint64()
         self.ffi.chfl_selection_evaluate(self, frame, matching)
 
@@ -72,7 +67,7 @@ class Selection(CxxPointer):
         size = self.size()
         result = []
         for match in matches:
-            assert(match[0] == size)
+            assert match[0] == size
             atoms = match[1]
             if size == 1:
                 result.append(atoms[0])

--- a/chemfiles/selection.py
+++ b/chemfiles/selection.py
@@ -26,7 +26,7 @@ class Selection(CxxPointer):
         Create a new :py:class:`Selection` from the given ``selection`` string.
         """
         ptr = self.ffi.chfl_selection(selection.encode("utf8"))
-        super(Selection, self).__init__(ptr)
+        super(Selection, self).__init__(ptr, is_const=False)
 
     def __copy__(self):
         return Selection.from_ptr(self.ffi.chfl_selection_copy(self))

--- a/chemfiles/topology.py
+++ b/chemfiles/topology.py
@@ -9,96 +9,86 @@ from .residue import Residue
 
 
 class Topology(CxxPointer):
-    '''
+    """
     A :py:class:`Topology` contains the definition of all the atoms in the
     system, and the liaisons between the atoms (bonds, angles, dihedrals, ...).
     It will also contain all the residues information if it is available.
-    '''
+    """
 
     def __init__(self):
-        '''Create a new empty :py:class:`Topology`.'''
+        """Create a new empty :py:class:`Topology`."""
         super(Topology, self).__init__(self.ffi.chfl_topology())
-
-    def __del__(self):
-        if hasattr(self, 'ptr'):
-            self.ffi.chfl_topology_free(self)
 
     def __copy__(self):
         return Topology.from_ptr(self.ffi.chfl_topology_copy(self))
 
     def __iter__(self):
-        for i in range(self.natoms()):
+        for i in range(self.atoms_count()):
             yield self.atom(i)
 
     def atom(self, i):
-        '''
+        """
         Get a copy of the :py:class:`Atom` at index ``i`` from this
         :py:class:`Topology`.
-        '''
-        if i >= self.natoms():
-            raise IndexError(
-                "atom index ({}) out of range for this topology".format(i)
-            )
-        return Atom.from_ptr(
-            self.ffi.chfl_atom_from_topology(self, c_uint64(i))
-        )
+        """
+        if i >= self.atoms_count():
+            raise IndexError("atom index ({}) out of range for this topology".format(i))
+        return Atom.from_ptr(self.ffi.chfl_atom_from_topology(self, c_uint64(i)))
 
-    def natoms(self):
-        '''Get the number of atoms in this :py:class:`Topology`.'''
-        natoms = c_uint64()
-        self.ffi.chfl_topology_atoms_count(self, natoms)
-        return natoms.value
+    def atoms_count(self):
+        """Get the number of atoms in this :py:class:`Topology`."""
+        count = c_uint64()
+        self.ffi.chfl_topology_atoms_count(self, count)
+        return count.value
 
     def __len__(self):
-        '''Get the number of atoms in this :py:class:`Topology`.'''
-        return self.natoms()
+        """Get the number of atoms in this :py:class:`Topology`."""
+        return self.atoms_count()
 
-    def resize(self, natoms):
-        '''
-        Resize this :py:class:`Topology` to contain ``natoms`` atoms. If the
+    def resize(self, count):
+        """
+        Resize this :py:class:`Topology` to contain ``count`` atoms. If the
         new number of atoms is bigger than the current number, new atoms will
         be created with an empty name and type. If it is lower than the current
         number of atoms, the last atoms will be removed, together with the
         associated bonds, angles and dihedrals.
-        '''
-        self.ffi.chfl_topology_resize(self, natoms)
+        """
+        self.ffi.chfl_topology_resize(self, count)
 
     def add_atom(self, atom):
-        '''
+        """
         Add a copy of the :py:class:`Atom` ``atom`` at the end of this
         :py:class:`Topology`.
-        '''
+        """
         self.ffi.chfl_topology_add_atom(self, atom)
 
     def remove(self, i):
-        '''
+        """
         Remove the :py:class:`Atom` at index `i` from this
         :py:class:`Topology`.
 
         This shifts all the atoms indexes after ``i`` by 1 (n becomes n-1).
-        '''
+        """
         self.ffi.chfl_topology_remove(self, c_uint64(i))
 
     def residue(self, i):
-        '''
+        """
         Get the :py:class:`Residue` at index ``i`` from this
         :py:class:`Topology`.
-        '''
+        """
         if i >= self.residues_count():
             raise IndexError(
                 "residue index ({}) out of range for this topology".format(i)
             )
-        return Residue.from_ptr(
-            self.ffi.chfl_residue_from_topology(self, c_uint64(i))
-        )
+        return Residue.from_ptr(self.ffi.chfl_residue_from_topology(self, c_uint64(i)))
 
     def residue_for_atom(self, i):
-        '''
+        """
         Get the :py:class:`Residue` containing the atom at index ``i`` from
         this :py:class:`Topology`. If the atom is not in a residue, this
         function returns None.
-        '''
-        if i >= self.natoms():
+        """
+        if i >= self.atoms_count():
             raise IndexError(
                 "residue index ({}) out of range for this topology".format(i)
             )
@@ -109,94 +99,94 @@ class Topology(CxxPointer):
             return None
 
     def residues_count(self):
-        '''Get the number of residues in this :py:class:`Topology`.'''
+        """Get the number of residues in this :py:class:`Topology`."""
         residues = c_uint64()
         self.ffi.chfl_topology_residues_count(self, residues)
         return residues.value
 
     def add_residue(self, residue):
-        '''
+        """
         Add the :py:class:`Residue` ``residue`` to this :py:class:`Topology`.
 
         The residue ``id`` must not already be in the topology, and the residue
         must contain only atoms that are not already in another residue.
-        '''
+        """
         self.ffi.chfl_topology_add_residue(self, residue)
 
     def residues_linked(self, first, second):
-        '''
+        """
         Check if the two :py:class:`Residue` ``first`` and ``second`` from this
         :py:class:`Topology` are linked together, *i.e.* if there is a bond
         between one atom in the first residue and one atom in the second one.
-        '''
+        """
         linked = c_bool()
         self.ffi.chfl_topology_residues_linked(self, first, second, linked)
         return linked.value
 
     def bonds_count(self):
-        '''Get the number of bonds in this :py:class:`Topology`.'''
+        """Get the number of bonds in this :py:class:`Topology`."""
         bonds = c_uint64()
         self.ffi.chfl_topology_bonds_count(self, bonds)
         return bonds.value
 
     def angles_count(self):
-        '''Get the number of angles in this :py:class:`Topology`.'''
+        """Get the number of angles in this :py:class:`Topology`."""
         angles = c_uint64()
         self.ffi.chfl_topology_angles_count(self, angles)
         return angles.value
 
     def dihedrals_count(self):
-        '''Get the number of dihedral angles in this :py:class:`Topology`.'''
+        """Get the number of dihedral angles in this :py:class:`Topology`."""
         dihedrals = c_uint64()
         self.ffi.chfl_topology_dihedrals_count(self, dihedrals)
         return dihedrals.value
 
     def impropers_count(self):
-        '''Get the number of improper angles in this :py:class:`Topology`.'''
+        """Get the number of improper angles in this :py:class:`Topology`."""
         impropers = c_uint64()
         self.ffi.chfl_topology_impropers_count(self, impropers)
         return impropers.value
 
     def bonds(self):
-        '''Get the list of bonds in this :py:class:`Topology`.'''
+        """Get the list of bonds in this :py:class:`Topology`."""
         n = self.bonds_count()
         bonds = np.zeros((n, 2), np.uint64)
         self.ffi.chfl_topology_bonds(self, bonds, c_uint64(n))
         return bonds
 
     def angles(self):
-        '''Get the list of angles in this :py:class:`Topology`.'''
+        """Get the list of angles in this :py:class:`Topology`."""
         n = self.angles_count()
         angles = np.zeros((n, 3), np.uint64)
         self.ffi.chfl_topology_angles(self, angles, c_uint64(n))
         return angles
 
     def dihedrals(self):
-        '''Get the list of dihedral angles in this :py:class:`Topology`.'''
+        """Get the list of dihedral angles in this :py:class:`Topology`."""
         n = self.dihedrals_count()
         dihedrals = np.zeros((n, 4), np.uint64)
         self.ffi.chfl_topology_dihedrals(self, dihedrals, c_uint64(n))
         return dihedrals
 
     def impropers(self):
-        '''Get the list of improper angles in this :py:class:`Topology`.'''
+        """Get the list of improper angles in this :py:class:`Topology`."""
         n = self.impropers_count()
         impropers = np.zeros((n, 4), np.uint64)
         self.ffi.chfl_topology_impropers(self, impropers, c_uint64(n))
         return impropers
 
     def add_bond(self, i, j):
-        '''
+        """
         Add a bond between the atoms at indexes ``i`` and ``j`` in this
         :py:class:`Topology`.
-        '''
+        """
         self.ffi.chfl_topology_add_bond(self, c_uint64(i), c_uint64(j))
 
     def remove_bond(self, i, j):
-        '''
+        """
         Remove any existing bond between the atoms at indexes ``i`` and ``j``
         in this :py:class:`Topology`.
 
         This function does nothing if there is no bond between ``i`` and ``j``.
-        '''
+        """
         self.ffi.chfl_topology_remove_bond(self, c_uint64(i), c_uint64(j))

--- a/chemfiles/topology.py
+++ b/chemfiles/topology.py
@@ -17,7 +17,7 @@ class Topology(CxxPointer):
 
     def __init__(self):
         """Create a new empty :py:class:`Topology`."""
-        super(Topology, self).__init__(self.ffi.chfl_topology())
+        super(Topology, self).__init__(self.ffi.chfl_topology(), is_const=False)
 
     def __copy__(self):
         return Topology.from_ptr(self.ffi.chfl_topology_copy(self))
@@ -73,20 +73,22 @@ class Topology(CxxPointer):
 
     def residue(self, i):
         """
-        Get the :py:class:`Residue` at index ``i`` from this
-        :py:class:`Topology`.
+        Get read-only access to the :py:class:`Residue` at index ``i`` from this
+        :py:class:`Topology`. The residue index in the topology does not
+        necessarily match the residue id.
         """
         if i >= self.residues_count():
             raise IndexError(
                 "residue index ({}) out of range for this topology".format(i)
             )
-        return Residue.from_ptr(self.ffi.chfl_residue_from_topology(self, c_uint64(i)))
+        ptr = self.ffi.chfl_residue_from_topology(self, c_uint64(i))
+        return Residue.from_const_ptr(ptr)
 
     def residue_for_atom(self, i):
         """
-        Get the :py:class:`Residue` containing the atom at index ``i`` from
-        this :py:class:`Topology`. If the atom is not in a residue, this
-        function returns None.
+        Get read-only access to the :py:class:`Residue` containing the atom at
+        index ``i`` from this :py:class:`Topology`; or ``None`` if the atom is
+        not part of a residue.
         """
         if i >= self.atoms_count():
             raise IndexError(
@@ -94,7 +96,7 @@ class Topology(CxxPointer):
             )
         ptr = self.ffi.chfl_residue_for_atom(self, c_uint64(i))
         if ptr:
-            return Residue.from_ptr(ptr)
+            return Residue.from_const_ptr(ptr)
         else:
             return None
 

--- a/chemfiles/trajectory.py
+++ b/chemfiles/trajectory.py
@@ -8,13 +8,13 @@ from .utils import ChemfilesError
 
 
 class Trajectory(CxxPointer):
-    '''
+    """
     A :py:class:`Trajectory` is a chemistry file on the hard drive. It is the
     main entry point of Chemfiles.
-    '''
+    """
 
     def __init__(self, path, mode="r", format=""):
-        '''
+        """
         Open the :py:class:`Trajectory` at the given ``path`` using the
         given ``mode`` and optional specific file ``format``.
 
@@ -25,7 +25,7 @@ class Trajectory(CxxPointer):
         the extension, or when there is not standard extension for this format.
         If `format` is an empty string, the format will be guessed from the
         file extension.
-        '''
+        """
         self.closed = False
         ptr = self.ffi.chfl_trajectory_with_format(
             path.encode("utf8"), mode.encode("utf8"), format.encode("utf8")
@@ -37,7 +37,7 @@ class Trajectory(CxxPointer):
             raise ChemfilesError("Can not use a closed Trajectory")
 
     def __del__(self):
-        if not self.closed and hasattr(self, 'ptr'):
+        if not self.closed and hasattr(self, "ptr"):
             self.close()
 
     def __enter__(self):
@@ -54,11 +54,11 @@ class Trajectory(CxxPointer):
             yield self.read_step(step, frame)
 
     def read(self, frame=None):
-        '''
+        """
         Read the next step of the :py:class:`Trajectory` and return the
         corresponding :py:class:`Frame`. If the ``frame`` parameter is given,
         reuse the corresponding allocation.
-        '''
+        """
         self._check_opened()
         if frame is None:
             frame = Frame()
@@ -66,11 +66,11 @@ class Trajectory(CxxPointer):
         return frame
 
     def read_step(self, step, frame=None):
-        '''
+        """
         Read a specific ``step`` in the :py:class:`Trajectory` and return the
         corresponding :py:class:`Frame`. If the ``frame`` parameter is given,
         reuse the corresponding allocation.
-        '''
+        """
         self._check_opened()
         if frame is None:
             frame = Frame()
@@ -78,12 +78,12 @@ class Trajectory(CxxPointer):
         return frame
 
     def write(self, frame):
-        '''Write a :py:class:`Frame` to the :py:class:`Trajectory`.'''
+        """Write a :py:class:`Frame` to the :py:class:`Trajectory`."""
         self._check_opened()
         self.ffi.chfl_trajectory_write(self, frame)
 
     def set_topology(self, topology, format=""):
-        '''
+        """
         Set the :py:class:`Topology` associated with a :py:class:`Trajectory`.
         This :py:class:`Topology` will be used when reading and writing the
         files, replacing any :py:class:`Topology` in the frames or files.
@@ -95,7 +95,7 @@ class Trajectory(CxxPointer):
         When reading from a file, if ``format`` is not the empty string, the
         code uses this file format instead of guessing it from the file
         extension.
-        '''
+        """
         self._check_opened()
         if isinstance(topology, Topology):
             self.ffi.chfl_trajectory_set_topology(self, topology)
@@ -105,29 +105,29 @@ class Trajectory(CxxPointer):
             )
 
     def set_cell(self, cell):
-        '''
+        """
         Set the :py:class:`UnitCell` associated with a :py:class:`Trajectory`.
         This :py:class:`UnitCell` will be used when reading and writing the
         files, replacing any :py:class:`UnitCell` in the frames or files.
-        '''
+        """
         self._check_opened()
         self.ffi.chfl_trajectory_set_cell(self, cell)
 
     def nsteps(self):
-        '''
+        """
         Get the number of steps (the number of frames) in a
         :py:class:`Trajectory`.
-        '''
+        """
         self._check_opened()
         nsteps = c_uint64()
         self.ffi.chfl_trajectory_nsteps(self, nsteps)
         return nsteps.value
 
     def close(self):
-        '''
+        """
         Close the :py:class:`Trajectory` and write any buffered content to the
         hard drive.
-        '''
+        """
         self._check_opened()
         self.closed = True
         self.ffi.chfl_trajectory_close(self)

--- a/chemfiles/trajectory.py
+++ b/chemfiles/trajectory.py
@@ -30,7 +30,7 @@ class Trajectory(CxxPointer):
         ptr = self.ffi.chfl_trajectory_with_format(
             path.encode("utf8"), mode.encode("utf8"), format.encode("utf8")
         )
-        super(Trajectory, self).__init__(ptr)
+        super(Trajectory, self).__init__(ptr, is_const=False)
 
     def _check_opened(self):
         if self.closed:

--- a/chemfiles/trajectory.py
+++ b/chemfiles/trajectory.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from ctypes import c_uint64
 
-from .utils import CxxPointer
+from ._utils import CxxPointer
 from .frame import Frame, Topology
-from .utils import ChemfilesError
+from .misc import ChemfilesError
 
 
 class Trajectory(CxxPointer):
@@ -32,7 +32,7 @@ class Trajectory(CxxPointer):
         )
         super(Trajectory, self).__init__(ptr, is_const=False)
 
-    def _check_opened(self):
+    def __check_opened(self):
         if self.closed:
             raise ChemfilesError("Can not use a closed Trajectory")
 
@@ -41,16 +41,16 @@ class Trajectory(CxxPointer):
             self.close()
 
     def __enter__(self):
-        self._check_opened()
+        self.__check_opened()
         return self
 
     def __exit__(self, *args):
         self.close()
 
     def __iter__(self):
-        self._check_opened()
+        self.__check_opened()
         frame = Frame()
-        for step in range(self.nsteps()):
+        for step in range(self.nsteps):
             yield self.read_step(step, frame)
 
     def read(self, frame=None):
@@ -59,7 +59,7 @@ class Trajectory(CxxPointer):
         corresponding :py:class:`Frame`. If the ``frame`` parameter is given,
         reuse the corresponding allocation.
         """
-        self._check_opened()
+        self.__check_opened()
         if frame is None:
             frame = Frame()
         self.ffi.chfl_trajectory_read(self, frame)
@@ -71,7 +71,7 @@ class Trajectory(CxxPointer):
         corresponding :py:class:`Frame`. If the ``frame`` parameter is given,
         reuse the corresponding allocation.
         """
-        self._check_opened()
+        self.__check_opened()
         if frame is None:
             frame = Frame()
         self.ffi.chfl_trajectory_read_step(self, c_uint64(step), frame)
@@ -79,7 +79,7 @@ class Trajectory(CxxPointer):
 
     def write(self, frame):
         """Write a :py:class:`Frame` to the :py:class:`Trajectory`."""
-        self._check_opened()
+        self.__check_opened()
         self.ffi.chfl_trajectory_write(self, frame)
 
     def set_topology(self, topology, format=""):
@@ -96,7 +96,7 @@ class Trajectory(CxxPointer):
         code uses this file format instead of guessing it from the file
         extension.
         """
-        self._check_opened()
+        self.__check_opened()
         if isinstance(topology, Topology):
             self.ffi.chfl_trajectory_set_topology(self, topology)
         else:
@@ -110,15 +110,16 @@ class Trajectory(CxxPointer):
         This :py:class:`UnitCell` will be used when reading and writing the
         files, replacing any :py:class:`UnitCell` in the frames or files.
         """
-        self._check_opened()
+        self.__check_opened()
         self.ffi.chfl_trajectory_set_cell(self, cell)
 
+    @property
     def nsteps(self):
         """
         Get the number of steps (the number of frames) in a
         :py:class:`Trajectory`.
         """
-        self._check_opened()
+        self.__check_opened()
         nsteps = c_uint64()
         self.ffi.chfl_trajectory_nsteps(self, nsteps)
         return nsteps.value
@@ -128,6 +129,6 @@ class Trajectory(CxxPointer):
         Close the :py:class:`Trajectory` and write any buffered content to the
         hard drive.
         """
-        self._check_opened()
+        self.__check_opened()
         self.closed = True
         self.ffi.chfl_trajectory_close(self)

--- a/chemfiles/trajectory.py
+++ b/chemfiles/trajectory.py
@@ -1,6 +1,7 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
-from ctypes import c_uint64
+import ctypes
+from ctypes import c_uint64, c_char_p
 
 from ._utils import CxxPointer
 from .frame import Frame, Topology
@@ -123,6 +124,14 @@ class Trajectory(CxxPointer):
         nsteps = c_uint64()
         self.ffi.chfl_trajectory_nsteps(self, nsteps)
         return nsteps.value
+
+    @property
+    def path(self):
+        """Get the path used to open this  :py:class:`Trajectory`."""
+        self.__check_opened()
+        path = c_char_p()
+        self.ffi.chfl_trajectory_path(self, path)
+        return path.value.decode('utf-8')
 
     def close(self):
         """

--- a/chemfiles/utils.py
+++ b/chemfiles/utils.py
@@ -9,12 +9,14 @@ __all__ = ["ChemfilesError", "set_warnings_callback", "add_configuration"]
 
 
 class ChemfilesWarning(UserWarning):
-    '''Warnings from the Chemfiles runtime.'''
+    """Warnings from the Chemfiles runtime."""
+
     pass
 
 
 class ChemfilesError(BaseException):
-    '''Exception class for errors in chemfiles'''
+    """Exception class for errors in chemfiles"""
+
     pass
 
 
@@ -29,8 +31,7 @@ class CxxPointer(object):
             raise TypeError("Can not pass None as a " + cls.__name__)
         if not isinstance(parameter, cls):
             raise TypeError(
-                "Can not pass " + parameter.__class__.__name__ +
-                " as a " + cls.__name__
+                "Can not pass " + parameter.__class__.__name__ + " as a " + cls.__name__
             )
         return parameter
 
@@ -39,11 +40,12 @@ class CxxPointer(object):
         self.ptr = ptr
         self._as_parameter_ = self.ptr
 
+    def __del__(self):
+        if hasattr(self, "ptr"):
+            self.ffi.chfl_free(self)
+
     @classmethod
     def from_ptr(cls, ptr):
-        '''
-
-        '''
         new = cls.__new__(cls)
         super(cls, new).__init__(ptr)
         return new
@@ -55,12 +57,12 @@ _CURRENT_CALLBACK = None
 
 
 def set_warnings_callback(function):
-    '''
+    """
     Call `function` on every warning event. The callback should take a string
     message and return nothing.
 
     By default, warnings are send to python `warnings` module.
-    '''
+    """
     from .ffi import chfl_warning_callback
 
     def callback(message):
@@ -77,7 +79,7 @@ def set_warnings_callback(function):
 
 
 def add_configuration(path):
-    '''
+    """
     Read configuration data from the file at ``path``.
 
     By default, chemfiles reads configuration from any file name `.chemfilesrc`
@@ -87,28 +89,28 @@ def add_configuration(path):
     This function will fail if there is no file at ``path``, or if the file is
     incorectly formatted. Data from the new configuration file will overwrite
     any existing data.
-    '''
+    """
     _get_c_library().chfl_add_configuration(path.encode("utf8"))
 
 
 def _last_error():
-    '''Get the last error from the chemfiles runtime.'''
+    """Get the last error from the chemfiles runtime."""
     return _get_c_library().chfl_last_error().decode("utf8")
 
 
 def _clear_errors():
-    '''Clear any error message saved in the chemfiles runtime.'''
+    """Clear any error message saved in the chemfiles runtime."""
     return _get_c_library().chfl_clear_errors()
 
 
 def _check_return_code(status, _function, _arguments):
-    '''Check that the function call was OK, and raise an exception if needed'''
+    """Check that the function call was OK, and raise an exception if needed"""
     if status.value != 0:
         raise ChemfilesError(_last_error())
 
 
 def _check_handle(handle):
-    '''Check that C allocated pointers are not NULL'''
+    """Check that C allocated pointers are not NULL"""
     try:
         handle.contents
     except ValueError:
@@ -124,24 +126,25 @@ def _set_default_warning_callback():
 
 
 def _call_with_growing_buffer(function, initial):
-    '''
+    """
     Call ``function`` with a growing buffer until the buffer is big enough.
     Use ``initial`` as the initial buffer size.
-    '''
+    """
+
     def buffer_was_big_enough(buffer):
         if len(buffer) < 2:
             return False
         else:
-            return buffer[-2] == b'\0'
+            return buffer[-2] == b"\0"
 
     size = initial
-    buffer = create_string_buffer(b'\0', size)
+    buffer = create_string_buffer(b"\0", size)
     function(buffer, c_uint64(size))
 
     while not buffer_was_big_enough(buffer):
         # Grow the buffer and retry
         size *= 2
-        buffer = create_string_buffer(b'\0', size)
+        buffer = create_string_buffer(b"\0", size)
         function(buffer, c_uint64(size))
 
     return buffer.value.decode("utf8")

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,27 +37,12 @@ You can also install this python module from sources if you have all the
     git clone https://github.com/chemfiles/chemfiles.py
     cd chemfiles.py
     git submodule update --init
-    mkdir build
-    cd build
-    cmake <CMAKE_OPTIONS> ..
-    make
-    make install
-
-The cmake options are the same one as the c++ library, you can find them `here
-<build-options_>`_. Additionally, there are some options to configure the Python
-interface:
-
-+------------------------------------------+---------------------+------------------------------+
-| Option                                   | Default value       | Effect/Informations          |
-+==========================================+=====================+==============================+
-| ``-DCHFL_PY_BUILD_DOCUMENTATION=ON|OFF`` | ``OFF``             | Build the python docs.       |
-+------------------------------------------+---------------------+------------------------------+
-| ``-DCHFL_PY_INTERNAL_CHEMFILES=ON|OFF``  | ``OFF``             | Force usage of the internal  |
-|                                          |                     | chemfiles instead of the     |
-|                                          |                     | system one.                  |
-+------------------------------------------+---------------------+------------------------------+
-
-.. _build-options: http://chemfiles.org/chemfiles/latest/installation.html#build-steps
+    # Install development dependencies
+    pip install -r dev-requirements.txt
+    # Install chemfiles
+    pip install .
+    # Optionally run the test suite
+    tox
 
 User documentation
 ^^^^^^^^^^^^^^^^^^

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -13,7 +13,7 @@ Chemfiles uses exceptions for error handling, throwing
 :py:class:`ChemfilesError <chemfiles.errors.ChemfilesError>` when an
 error occurs.
 
-.. automodule:: chemfiles.utils
+.. automodule:: chemfiles.misc
     :members:
 
 Trajectory class
@@ -42,6 +42,9 @@ UnitCell class
 
 Topology class
 --------------
+
+.. autoclass:: BondOrder
+    :members:
 
 .. autoclass:: Topology
     :members:

--- a/scripts/setup-appveyor.ps1
+++ b/scripts/setup-appveyor.ps1
@@ -1,30 +1,3 @@
-# ======= workaround for the issues with MinGW builders
-# see https://github.com/appveyor/ci/issues/1804
-$cmake_uninstall = "${env:ProgramFiles(x86)}\CMake\Uninstall.exe"
-if([IO.File]::Exists($cmake_uninstall)) {
-    Write-Host "Uninstalling previous CMake ..." -ForegroundColor Cyan
-    # uninstall existent
-    "`"$cmake_uninstall`" /S" | out-file ".\uninstall-cmake.cmd" -Encoding ASCII
-    & .\uninstall-cmake.cmd
-    del .\uninstall-cmake.cmd
-    Start-Sleep -s 10
-}
-
-Write-Host "Installing CMake 3.8.2 ..." -ForegroundColor Cyan
-$cmake_install = "$($env:TEMP)\cmake-3.8.2-win32-x86.msi"
-
-(New-Object Net.WebClient).DownloadFile('https://cmake.org/files/v3.8/cmake-3.8.2-win32-x86.msi', $cmake_install)
-
-cmd /c start /wait msiexec /i $cmake_install /quiet
-del $cmake_install
-
-add-path 'C:\Program Files (x86)\CMake\bin'
-remove-path 'C:\ProgramData\chocolatey\bin'
-add-path 'C:\ProgramData\chocolatey\bin'
-
-Write-Host "CMake 3.8.2 installed" -ForegroundColor Green
-# ======= end of the workaround
-
 if ("$env:CXX_PATH" -ne "") {
     $env:PATH += ";$env:CXX_PATH"
 }

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ class universal_wheel(bdist_wheel):
     # Workaround until https://github.com/pypa/wheel/issues/185 is resolved
     def get_tag(self):
         tag = bdist_wheel.get_tag(self)
-        return ('py2.py3', "none") + tag[2:]
+        return ("py2.py3", "none") + tag[2:]
 
 
-with open('requirements.txt', 'r') as fp:
+with open("requirements.txt", "r") as fp:
     requirements = list(filter(bool, (line.strip() for line in fp)))
     if sys.hexversion >= 0x03040000:
         requirements = list(filter(lambda r: r != "enum34", requirements))
@@ -33,7 +33,7 @@ setup(
     license="BSD",
     keywords="chemistry computational cheminformatics files formats",
     url="http://github.com/chemfiles/chemfiles.py",
-    packages=['chemfiles'],
+    packages=["chemfiles"],
     zip_safe=False,
     install_requires=requirements,
     setup_requires=["scikit-build"],
@@ -50,8 +50,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Chemistry",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Utilities"
+        "Topic :: Utilities",
     ],
     cmake_install_dir="chemfiles",
-    cmdclass={'bdist_wheel': universal_wheel},
+    cmdclass={"bdist_wheel": universal_wheel},
 )

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,6 @@ setup(
         "Topic :: Utilities",
     ],
     cmake_install_dir="chemfiles",
+    cmake_args=['-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9'],
     cmdclass={"bdist_wheel": universal_wheel},
 )

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,0 +1,14 @@
+# -*- coding=utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+import chemfiles
+
+
+class RemoveChemfilesWarnings(object):
+    def __enter__(self):
+        chemfiles.set_warnings_callback(lambda u: None)
+
+    def __exit__(self, *args):
+        chemfiles.misc._set_default_warning_callback()
+
+
+remove_warnings = RemoveChemfilesWarnings()

--- a/tests/atom.py
+++ b/tests/atom.py
@@ -83,7 +83,7 @@ class TestAtom(unittest.TestCase):
         atom["bar"] = "baz"
 
         self.assertEqual(atom.properties_count(), 2)
-        self.assertEqual(atom.list_properties(), ["bar", "foo"])
+        self.assertEqual(set(atom.list_properties()), {"bar", "foo"})
 
 
 if __name__ == "__main__":

--- a/tests/atom.py
+++ b/tests/atom.py
@@ -19,6 +19,10 @@ class TestAtom(unittest.TestCase):
         self.assertEqual(atom.name, "Zn")
         self.assertEqual(cloned.name, "He")
 
+    def test_very_long_name(self):
+        atom = Atom("He" * 128)
+        self.assertEqual(atom.name, "He" * 128)
+
     def test_name(self):
         atom = Atom("He")
         self.assertEqual(atom.name, "He")
@@ -74,7 +78,12 @@ class TestAtom(unittest.TestCase):
 
         with remove_warnings:
             with self.assertRaises(ChemfilesError):
-                atom["bar"]
+                _ = atom["bar"]
+
+        atom["bar"] = "baz"
+
+        self.assertEqual(atom.properties_count(), 2)
+        self.assertEqual(atom.list_properties(), ["bar", "foo"])
 
 
 if __name__ == "__main__":

--- a/tests/atom.py
+++ b/tests/atom.py
@@ -4,6 +4,7 @@ import unittest
 import copy
 
 from chemfiles import Atom, ChemfilesError
+from utils import remove_warnings
 
 
 class TestAtom(unittest.TestCase):
@@ -71,7 +72,8 @@ class TestAtom(unittest.TestCase):
         atom.set("foo", False)
         self.assertEqual(atom.get("foo"), False)
 
-        self.assertRaises(ChemfilesError, atom.get, "bar")
+        with remove_warnings:
+            self.assertRaises(ChemfilesError, atom.get, "bar")
 
 
 if __name__ == "__main__":

--- a/tests/atom.py
+++ b/tests/atom.py
@@ -80,6 +80,17 @@ class TestAtom(unittest.TestCase):
             with self.assertRaises(ChemfilesError):
                 _ = atom["bar"]
 
+            with self.assertRaises(ChemfilesError):
+                atom[3] = "test"
+
+            with self.assertRaises(ChemfilesError):
+                _ = atom[3]
+
+        # Check that enabling indexing/__getitem__ did not enable iteration
+        with self.assertRaises(TypeError):
+            for i in atom:
+                pass
+
         atom["bar"] = "baz"
 
         self.assertEqual(atom.properties_count(), 2)

--- a/tests/atom.py
+++ b/tests/atom.py
@@ -4,7 +4,7 @@ import unittest
 import copy
 
 from chemfiles import Atom, ChemfilesError
-from utils import remove_warnings
+from _utils import remove_warnings
 
 
 class TestAtom(unittest.TestCase):
@@ -12,68 +12,69 @@ class TestAtom(unittest.TestCase):
         atom = Atom("He")
         cloned = copy.copy(atom)
 
-        self.assertEqual(atom.name(), "He")
-        self.assertEqual(cloned.name(), "He")
+        self.assertEqual(atom.name, "He")
+        self.assertEqual(cloned.name, "He")
 
-        atom.set_name("Zn")
-        self.assertEqual(atom.name(), "Zn")
-        self.assertEqual(cloned.name(), "He")
+        atom.name = "Zn"
+        self.assertEqual(atom.name, "Zn")
+        self.assertEqual(cloned.name, "He")
 
     def test_name(self):
         atom = Atom("He")
-        self.assertEqual(atom.name(), "He")
-        self.assertEqual(atom.full_name(), "Helium")
+        self.assertEqual(atom.name, "He")
+        self.assertEqual(atom.full_name, "Helium")
 
-        atom.set_name("Zn")
-        self.assertEqual(atom.name(), "Zn")
+        atom.name = "Zn"
+        self.assertEqual(atom.name, "Zn")
 
     def test_type(self):
         atom = Atom("He")
-        self.assertEqual(atom.type(), "He")
-        self.assertEqual(atom.full_name(), "Helium")
+        self.assertEqual(atom.type, "He")
+        self.assertEqual(atom.full_name, "Helium")
 
-        atom.set_type("Zn")
-        self.assertEqual(atom.type(), "Zn")
-        self.assertEqual(atom.full_name(), "Zinc")
+        atom.type = "Zn"
+        self.assertEqual(atom.type, "Zn")
+        self.assertEqual(atom.full_name, "Zinc")
 
         atom = Atom("He2", "H")
-        self.assertEqual(atom.name(), "He2")
-        self.assertEqual(atom.type(), "H")
+        self.assertEqual(atom.name, "He2")
+        self.assertEqual(atom.type, "H")
 
     def test_mass(self):
         atom = Atom("He")
-        self.assertAlmostEqual(atom.mass(), 4.002602, 6)
-        atom.set_mass(1.0)
-        self.assertEqual(atom.mass(), 1.0)
+        self.assertAlmostEqual(atom.mass, 4.002602, 6)
+        atom.mass = 1.0
+        self.assertEqual(atom.mass, 1.0)
 
     def test_charge(self):
         atom = Atom("He")
-        self.assertEqual(atom.charge(), 0.0)
-        atom.set_charge(-1.5)
-        self.assertEqual(atom.charge(), -1.5)
+        self.assertEqual(atom.charge, 0.0)
+        atom.charge = -1.5
+        self.assertEqual(atom.charge, -1.5)
 
     def test_radii(self):
-        self.assertAlmostEqual(Atom("He").vdw_radius(), 1.4, 2)
-        self.assertAlmostEqual(Atom("He").covalent_radius(), 0.32, 3)
+        self.assertAlmostEqual(Atom("He").vdw_radius, 1.4, 2)
+        self.assertAlmostEqual(Atom("He").covalent_radius, 0.32, 3)
 
-        self.assertEqual(Atom("H1").vdw_radius(), 0)
-        self.assertEqual(Atom("H1").covalent_radius(), 0)
+        self.assertEqual(Atom("H1").vdw_radius, 0)
+        self.assertEqual(Atom("H1").covalent_radius, 0)
 
     def test_atomic_number(self):
-        self.assertEqual(Atom("He").atomic_number(), 2)
-        self.assertEqual(Atom("H1").atomic_number(), 0)
+        self.assertEqual(Atom("He").atomic_number, 2)
+        self.assertEqual(Atom("H1").atomic_number, 0)
 
     def test_property(self):
         atom = Atom("He")
 
-        atom.set("foo", 3)
-        self.assertEqual(atom.get("foo"), 3.0)
+        atom["foo"] = 3
+        self.assertEqual(atom["foo"], 3.0)
 
-        atom.set("foo", False)
-        self.assertEqual(atom.get("foo"), False)
+        atom["foo"] = False
+        self.assertEqual(atom["foo"], False)
 
         with remove_warnings:
-            self.assertRaises(ChemfilesError, atom.get, "bar")
+            with self.assertRaises(ChemfilesError):
+                atom["bar"]
 
 
 if __name__ == "__main__":

--- a/tests/atoms.py
+++ b/tests/atoms.py
@@ -11,33 +11,33 @@ class TestAtom(unittest.TestCase):
         atom = Atom("He")
         cloned = copy.copy(atom)
 
-        self.assertEqual(atom.name(), 'He')
-        self.assertEqual(cloned.name(), 'He')
+        self.assertEqual(atom.name(), "He")
+        self.assertEqual(cloned.name(), "He")
 
         atom.set_name("Zn")
-        self.assertEqual(atom.name(), 'Zn')
-        self.assertEqual(cloned.name(), 'He')
+        self.assertEqual(atom.name(), "Zn")
+        self.assertEqual(cloned.name(), "He")
 
     def test_name(self):
         atom = Atom("He")
-        self.assertEqual(atom.name(), 'He')
-        self.assertEqual(atom.full_name(), 'Helium')
+        self.assertEqual(atom.name(), "He")
+        self.assertEqual(atom.full_name(), "Helium")
 
         atom.set_name("Zn")
-        self.assertEqual(atom.name(), 'Zn')
+        self.assertEqual(atom.name(), "Zn")
 
     def test_type(self):
         atom = Atom("He")
-        self.assertEqual(atom.type(), 'He')
-        self.assertEqual(atom.full_name(), 'Helium')
+        self.assertEqual(atom.type(), "He")
+        self.assertEqual(atom.full_name(), "Helium")
 
         atom.set_type("Zn")
-        self.assertEqual(atom.type(), 'Zn')
-        self.assertEqual(atom.full_name(), 'Zinc')
+        self.assertEqual(atom.type(), "Zn")
+        self.assertEqual(atom.full_name(), "Zinc")
 
         atom = Atom("He2", "H")
-        self.assertEqual(atom.name(), 'He2')
-        self.assertEqual(atom.type(), 'H')
+        self.assertEqual(atom.name(), "He2")
+        self.assertEqual(atom.type(), "H")
 
     def test_mass(self):
         atom = Atom("He")
@@ -74,5 +74,5 @@ class TestAtom(unittest.TestCase):
         self.assertRaises(ChemfilesError, atom.get, "bar")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -5,7 +5,7 @@ import copy
 
 from chemfiles import UnitCell, CellShape
 from chemfiles import ChemfilesError
-from utils import remove_warnings
+from _utils import remove_warnings
 
 
 class TestUnitCell(unittest.TestCase):
@@ -13,51 +13,52 @@ class TestUnitCell(unittest.TestCase):
         cell = UnitCell(3, 4, 5)
         cloned = copy.copy(cell)
 
-        self.assertEqual(cell.lengths(), (3.0, 4.0, 5.0))
-        self.assertEqual(cloned.lengths(), (3.0, 4.0, 5.0))
+        self.assertEqual(cell.lengths, (3.0, 4.0, 5.0))
+        self.assertEqual(cloned.lengths, (3.0, 4.0, 5.0))
 
-        cell.set_lengths(10, 11, 12)
-        self.assertEqual(cell.lengths(), (10.0, 11.0, 12.0))
-        self.assertEqual(cloned.lengths(), (3.0, 4.0, 5.0))
+        cell.lengths = 10, 11, 12
+        self.assertEqual(cell.lengths, (10.0, 11.0, 12.0))
+        self.assertEqual(cloned.lengths, (3.0, 4.0, 5.0))
 
     def test_lengths(self):
         cell = UnitCell(3, 4, 5)
-        self.assertEqual(cell.lengths(), (3.0, 4.0, 5.0))
-        cell.set_lengths(10, 11, 12)
-        self.assertEqual(cell.lengths(), (10.0, 11.0, 12.0))
+        self.assertEqual(cell.lengths, (3.0, 4.0, 5.0))
+        cell.lengths = [10, 11, 12]
+        self.assertEqual(cell.lengths, (10.0, 11.0, 12.0))
 
     def test_angles(self):
         cell = UnitCell(3, 4, 5)
-        self.assertEqual(cell.angles(), (90.0, 90.0, 90.0))
+        self.assertEqual(cell.angles, (90.0, 90.0, 90.0))
 
-        self.assertEqual(cell.shape(), CellShape.Orthorhombic)
+        self.assertEqual(cell.shape, CellShape.Orthorhombic)
         with remove_warnings:
-            self.assertRaises(ChemfilesError, cell.set_angles, 80, 89, 110)
+            with self.assertRaises(ChemfilesError):
+                cell.angles = [80, 89, 110]
 
-        cell.set_shape(CellShape.Triclinic)
-        cell.set_angles(80, 89, 110)
-        self.assertEqual(cell.angles(), (80.0, 89.0, 110.0))
+        cell.shape = CellShape.Triclinic
+        cell.angles = [80, 89, 110]
+        self.assertEqual(cell.angles, (80.0, 89.0, 110.0))
 
     def test_volume(self):
         cell = UnitCell(3, 4, 5)
-        self.assertEqual(cell.volume(), 3 * 4 * 5)
+        self.assertEqual(cell.volume, 3 * 4 * 5)
 
     def test_matrix(self):
         cell = UnitCell(3, 4, 5)
         expected = [(3, 0, 0), (0, 4, 0), (0, 0, 5)]
-        matrix = cell.matrix()
+        matrix = cell.matrix
         for i in range(3):
             for j in range(3):
                 self.assertAlmostEqual(matrix[i][j], expected[i][j])
 
     def test_shape(self):
         cell = UnitCell(3, 4, 5)
-        self.assertEqual(cell.shape(), CellShape.Orthorhombic)
-        cell.set_shape(CellShape.Triclinic)
-        self.assertEqual(cell.shape(), CellShape.Triclinic)
+        self.assertEqual(cell.shape, CellShape.Orthorhombic)
+        cell.shape = CellShape.Triclinic
+        self.assertEqual(cell.shape, CellShape.Triclinic)
 
         cell = UnitCell(3, 4, 5, 100, 120, 130)
-        self.assertEqual(cell.shape(), CellShape.Triclinic)
+        self.assertEqual(cell.shape, CellShape.Triclinic)
 
     def test_wrap(self):
         cell = UnitCell(3, 4, 5)

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -5,6 +5,7 @@ import copy
 
 from chemfiles import UnitCell, CellShape
 from chemfiles import ChemfilesError
+from utils import remove_warnings
 
 
 class TestUnitCell(unittest.TestCase):
@@ -30,7 +31,8 @@ class TestUnitCell(unittest.TestCase):
         self.assertEqual(cell.angles(), (90.0, 90.0, 90.0))
 
         self.assertEqual(cell.shape(), CellShape.Orthorhombic)
-        self.assertRaises(ChemfilesError, cell.set_angles, 80, 89, 110)
+        with remove_warnings:
+            self.assertRaises(ChemfilesError, cell.set_angles, 80, 89, 110)
 
         cell.set_shape(CellShape.Triclinic)
         cell.set_angles(80, 89, 110)

--- a/tests/cells.py
+++ b/tests/cells.py
@@ -67,5 +67,5 @@ class TestUnitCell(unittest.TestCase):
         self.assertEqual(wrapped[2], -0.5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/frame.py
+++ b/tests/frame.py
@@ -97,6 +97,9 @@ class TestFrame(unittest.TestCase):
         self.assertEqual(frame.cell().angles(), cell.angles())
         self.assertEqual(frame.cell().shape(), cell.shape())
 
+        frame.cell().set_lengths(3, 4, 5)
+        self.assertEqual(frame.cell().lengths(), (3, 4, 5))
+
     def test_topology(self):
         frame = Frame()
         frame.resize(2)

--- a/tests/frame.py
+++ b/tests/frame.py
@@ -5,7 +5,8 @@ import copy
 import math
 import numpy as np
 
-from chemfiles import Frame, UnitCell, Topology, Atom, Residue, ChemfilesError, CellShape
+from chemfiles import Frame, UnitCell, Topology, Atom, Residue, ChemfilesError
+from chemfiles import BondOrder, CellShape
 from _utils import remove_warnings
 
 
@@ -139,7 +140,12 @@ class TestFrame(unittest.TestCase):
 
         with remove_warnings:
             with self.assertRaises(ChemfilesError):
-                frame["bar"]
+                _ = frame["bar"]
+
+        frame["bar"] = "baz"
+
+        self.assertEqual(frame.properties_count(), 2)
+        self.assertEqual(frame.list_properties(), ["bar", "foo"])
 
     def test_distance(self):
         frame = Frame()
@@ -185,10 +191,15 @@ class TestFrame(unittest.TestCase):
 
         frame.add_bond(0, 1)
         frame.add_bond(3, 4)
-        frame.add_bond(2, 1)
+        frame.add_bond(2, 1, BondOrder.Qintuplet)
 
         self.assertEqual(
             frame.topology.bonds.all(), np.array([[0, 1], [1, 2], [3, 4]]).all()
+        )
+
+        self.assertEqual(
+            frame.topology.bonds_orders,
+            [BondOrder.Unknown, BondOrder.Qintuplet, BondOrder.Unknown]
         )
 
         frame.remove_bond(3, 4)

--- a/tests/frame.py
+++ b/tests/frame.py
@@ -6,6 +6,7 @@ import math
 import numpy as np
 
 from chemfiles import Frame, UnitCell, Topology, Atom, Residue, ChemfilesError
+from utils import remove_warnings
 
 
 class TestFrame(unittest.TestCase):
@@ -143,7 +144,8 @@ class TestFrame(unittest.TestCase):
         frame.set("foo", False)
         self.assertEqual(frame.get("foo"), False)
 
-        self.assertRaises(ChemfilesError, frame.get, "bar")
+        with remove_warnings:
+            self.assertRaises(ChemfilesError, frame.get, "bar")
 
     def test_distance(self):
         frame = Frame()

--- a/tests/frame.py
+++ b/tests/frame.py
@@ -13,24 +13,24 @@ class TestFrame(unittest.TestCase):
         frame = Frame()
         cloned = copy.copy(frame)
 
-        self.assertEqual(frame.natoms(), 0)
-        self.assertEqual(cloned.natoms(), 0)
+        self.assertEqual(frame.atoms_count(), 0)
+        self.assertEqual(cloned.atoms_count(), 0)
 
         frame.resize(6)
-        self.assertEqual(frame.natoms(), 6)
-        self.assertEqual(cloned.natoms(), 0)
+        self.assertEqual(frame.atoms_count(), 6)
+        self.assertEqual(cloned.atoms_count(), 0)
 
-    def test_natoms(self):
+    def test_atoms_count(self):
         frame = Frame()
-        self.assertEqual(frame.natoms(), 0)
+        self.assertEqual(frame.atoms_count(), 0)
         self.assertEqual(len(frame), 0)
 
         frame.resize(4)
-        self.assertEqual(frame.natoms(), 4)
+        self.assertEqual(frame.atoms_count(), 4)
         self.assertEqual(len(frame), 4)
 
         frame.remove(2)
-        self.assertEqual(frame.natoms(), 3)
+        self.assertEqual(frame.atoms_count(), 3)
         self.assertEqual(len(frame), 3)
 
     def test_add_atom(self):
@@ -48,10 +48,10 @@ class TestFrame(unittest.TestCase):
         frame = Frame()
         frame.resize(4)
 
-        expected = np.array([[1.0, 2.0, 3.0],
-                             [4.0, 5.0, 6.0],
-                             [7.0, 8.0, 9.0],
-                             [10.0, 11.0, 12.0]], np.float64)
+        expected = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+            np.float64,
+        )
         positions = frame.positions()
         np.copyto(positions, expected)
         self.assertEqual(frame.positions().all(), expected.all())
@@ -71,10 +71,10 @@ class TestFrame(unittest.TestCase):
         frame.add_velocities()
         self.assertTrue(frame.has_velocities())
 
-        expected = np.array([[1.0, 2.0, 3.0],
-                             [4.0, 5.0, 6.0],
-                             [7.0, 8.0, 9.0],
-                             [10.0, 11.0, 12.0]], np.float64)
+        expected = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+            np.float64,
+        )
         velocities = frame.velocities()
         np.copyto(velocities, expected)
         self.assertEqual(frame.velocities().all(), expected.all())
@@ -192,8 +192,7 @@ class TestFrame(unittest.TestCase):
         frame.add_bond(2, 1)
 
         self.assertEqual(
-            frame.topology().bonds().all(),
-            np.array([[0, 1], [1, 2], [3, 4]]).all()
+            frame.topology().bonds().all(), np.array([[0, 1], [1, 2], [3, 4]]).all()
         )
 
         frame.remove_bond(3, 4)
@@ -202,8 +201,7 @@ class TestFrame(unittest.TestCase):
         frame.remove_bond(0, 4)
 
         self.assertEqual(
-            frame.topology().bonds().all(),
-            np.array([[0, 1], [1, 2]]).all()
+            frame.topology().bonds().all(), np.array([[0, 1], [1, 2]]).all()
         )
 
     def test_residues(self):
@@ -217,5 +215,5 @@ class TestFrame(unittest.TestCase):
         self.assertEqual(topology.residue(0).name(), "Foo")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/frame.py
+++ b/tests/frame.py
@@ -5,8 +5,8 @@ import copy
 import math
 import numpy as np
 
-from chemfiles import Frame, UnitCell, Topology, Atom, Residue, ChemfilesError
-from utils import remove_warnings
+from chemfiles import Frame, UnitCell, Topology, Atom, Residue, ChemfilesError, CellShape
+from _utils import remove_warnings
 
 
 class TestFrame(unittest.TestCase):
@@ -14,36 +14,33 @@ class TestFrame(unittest.TestCase):
         frame = Frame()
         cloned = copy.copy(frame)
 
-        self.assertEqual(frame.atoms_count(), 0)
-        self.assertEqual(cloned.atoms_count(), 0)
+        self.assertEqual(len(frame.atoms), 0)
+        self.assertEqual(len(cloned.atoms), 0)
 
         frame.resize(6)
-        self.assertEqual(frame.atoms_count(), 6)
-        self.assertEqual(cloned.atoms_count(), 0)
+        self.assertEqual(len(frame.atoms), 6)
+        self.assertEqual(len(cloned.atoms), 0)
 
     def test_atoms_count(self):
         frame = Frame()
-        self.assertEqual(frame.atoms_count(), 0)
-        self.assertEqual(len(frame), 0)
+        self.assertEqual(len(frame.atoms), 0)
 
         frame.resize(4)
-        self.assertEqual(frame.atoms_count(), 4)
-        self.assertEqual(len(frame), 4)
+        self.assertEqual(len(frame.atoms), 4)
 
         frame.remove(2)
-        self.assertEqual(frame.atoms_count(), 3)
-        self.assertEqual(len(frame), 3)
+        self.assertEqual(len(frame.atoms), 3)
 
     def test_add_atom(self):
         frame = Frame()
         frame.add_atom(Atom("F"), (3, 4, 5))
-        self.assertEqual(len(frame), 1)
-        self.assertEqual(list(frame.positions()[0]), [3, 4, 5])
+        self.assertEqual(len(frame.atoms), 1)
+        self.assertEqual(list(frame.positions[0]), [3, 4, 5])
 
         frame.add_velocities()
         frame.add_atom(Atom("F"), (-3, -4, 5), (1, 0, 1))
-        self.assertEqual(list(frame.positions()[1]), [-3, -4, 5])
-        self.assertEqual(list(frame.velocities()[1]), [1, 0, 1])
+        self.assertEqual(list(frame.positions[1]), [-3, -4, 5])
+        self.assertEqual(list(frame.velocities[1]), [1, 0, 1])
 
     def test_positions(self):
         frame = Frame()
@@ -53,16 +50,14 @@ class TestFrame(unittest.TestCase):
             [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
             np.float64,
         )
-        positions = frame.positions()
-        np.copyto(positions, expected)
-        self.assertEqual(frame.positions().all(), expected.all())
+        np.copyto(frame.positions, expected)
+        self.assertEqual(frame.positions.all(), expected.all())
 
-        positions[3, 2] = 42
-        self.assertEqual(frame.positions()[3, 2], 42)
+        frame.positions[3, 2] = 42
+        self.assertEqual(frame.positions[3, 2], 42)
 
         # Checking empty frame positions access
-        frame = Frame()
-        positions = frame.positions()
+        _ = Frame().positions
 
     def test_velocities(self):
         frame = Frame()
@@ -76,83 +71,79 @@ class TestFrame(unittest.TestCase):
             [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
             np.float64,
         )
-        velocities = frame.velocities()
-        np.copyto(velocities, expected)
-        self.assertEqual(frame.velocities().all(), expected.all())
+        np.copyto(frame.velocities, expected)
+        self.assertEqual(frame.velocities.all(), expected.all())
 
-        velocities[3, 2] = 42
-        self.assertEqual(frame.velocities()[3, 2], 42)
+        frame.velocities[3, 2] = 42
+        self.assertEqual(frame.velocities[3, 2], 42)
 
         # Checking empty frame velocities access
         frame = Frame()
         frame.add_velocities()
-        velocities = frame.velocities()
+        _ = frame.velocities
 
     def test_cell(self):
         frame = Frame()
-        cell = UnitCell(1, 2, 4)
+        frame.cell = UnitCell(1, 2, 4)
+        self.assertEqual(frame.cell.lengths, (1, 2, 4))
+        self.assertEqual(frame.cell.angles, (90, 90, 90))
+        self.assertEqual(frame.cell.shape, CellShape.Orthorhombic)
 
-        frame.set_cell(cell)
-        self.assertEqual(frame.cell().lengths(), cell.lengths())
-        self.assertEqual(frame.cell().angles(), cell.angles())
-        self.assertEqual(frame.cell().shape(), cell.shape())
-
-        frame.cell().set_lengths(3, 4, 5)
-        self.assertEqual(frame.cell().lengths(), (3, 4, 5))
+        frame.cell.lengths = (3, 4, 5)
+        self.assertEqual(frame.cell.lengths, (3, 4, 5))
 
     def test_topology(self):
         frame = Frame()
         frame.resize(2)
 
         topology = Topology()
-        topology.add_atom(Atom("Zn"))
-        topology.add_atom(Atom("Ar"))
+        topology.atoms.append(Atom("Zn"))
+        topology.atoms.append(Atom("Ar"))
 
-        frame.set_topology(topology)
+        frame.topology = topology
+        self.assertEqual(frame.topology.atoms[0].name, "Zn")
+        self.assertEqual(frame.topology.atoms[1].name, "Ar")
 
-        topology = frame.topology()
-        self.assertEqual(topology.atom(0).name(), "Zn")
-        self.assertEqual(topology.atom(1).name(), "Ar")
-
-        self.assertEqual(frame.atom(0).name(), "Zn")
-        self.assertEqual(frame.atom(1).name(), "Ar")
+        self.assertEqual(frame.atoms[0].name, "Zn")
+        self.assertEqual(frame.atoms[1].name, "Ar")
 
     def test_step(self):
         frame = Frame()
-        self.assertEqual(frame.step(), 0)
-        frame.set_step(42)
-        self.assertEqual(frame.step(), 42)
+        self.assertEqual(frame.step, 0)
+        frame.step = 42
+        self.assertEqual(frame.step, 42)
 
     def test_out_of_bounds(self):
         frame = Frame()
         frame.resize(3)
-        frame.atom(2)
-        self.assertRaises(IndexError, frame.atom, 6)
+        _ = frame.atoms[2]
+        with self.assertRaises(IndexError):
+            _ = frame.atoms[6]
 
     def test_iter(self):
         frame = Frame()
         frame.resize(3)
-        i = 0
-        for atom in frame:
-            self.assertEqual(atom.name(), "")
-            i += 1
-        self.assertEqual(i, 3)
+
+        for i, atom in enumerate(frame.atoms):
+            self.assertEqual(atom.name, "")
+        self.assertEqual(i, 2)
 
     def test_property(self):
         frame = Frame()
 
-        frame.set("foo", 3)
-        self.assertEqual(frame.get("foo"), 3.0)
+        frame["foo"] = 3
+        self.assertEqual(frame["foo"], 3.0)
 
-        frame.set("foo", False)
-        self.assertEqual(frame.get("foo"), False)
+        frame["foo"] = False
+        self.assertEqual(frame["foo"], False)
 
         with remove_warnings:
-            self.assertRaises(ChemfilesError, frame.get, "bar")
+            with self.assertRaises(ChemfilesError):
+                frame["bar"]
 
     def test_distance(self):
         frame = Frame()
-        frame.set_cell(UnitCell(3.0, 4.0, 5.0))
+        frame.cell = UnitCell(3.0, 4.0, 5.0)
         frame.add_atom(Atom(""), (0, 0, 0))
         frame.add_atom(Atom(""), (1, 2, 6))
 
@@ -197,7 +188,7 @@ class TestFrame(unittest.TestCase):
         frame.add_bond(2, 1)
 
         self.assertEqual(
-            frame.topology().bonds().all(), np.array([[0, 1], [1, 2], [3, 4]]).all()
+            frame.topology.bonds.all(), np.array([[0, 1], [1, 2], [3, 4]]).all()
         )
 
         frame.remove_bond(3, 4)
@@ -206,7 +197,7 @@ class TestFrame(unittest.TestCase):
         frame.remove_bond(0, 4)
 
         self.assertEqual(
-            frame.topology().bonds().all(), np.array([[0, 1], [1, 2]]).all()
+            frame.topology.bonds.all(), np.array([[0, 1], [1, 2]]).all()
         )
 
     def test_residues(self):
@@ -215,9 +206,8 @@ class TestFrame(unittest.TestCase):
         frame.add_residue(Residue("Foo"))
         frame.add_residue(Residue("Foo"))
 
-        topology = frame.topology()
-        self.assertEqual(topology.residues_count(), 3)
-        self.assertEqual(topology.residue(0).name(), "Foo")
+        self.assertEqual(len(frame.topology.residues), 3)
+        self.assertEqual(frame.topology.residues[0].name, "Foo")
 
 
 if __name__ == "__main__":

--- a/tests/frame.py
+++ b/tests/frame.py
@@ -142,6 +142,17 @@ class TestFrame(unittest.TestCase):
             with self.assertRaises(ChemfilesError):
                 _ = frame["bar"]
 
+            with self.assertRaises(ChemfilesError):
+                frame[3] = "test"
+
+            with self.assertRaises(ChemfilesError):
+                _ = frame[3]
+
+        # Check that enabling indexing/__getitem__ did not enable iteration
+        with self.assertRaises(TypeError):
+            for i in frame:
+                pass
+
         frame["bar"] = "baz"
 
         self.assertEqual(frame.properties_count(), 2)

--- a/tests/frame.py
+++ b/tests/frame.py
@@ -145,7 +145,7 @@ class TestFrame(unittest.TestCase):
         frame["bar"] = "baz"
 
         self.assertEqual(frame.properties_count(), 2)
-        self.assertEqual(frame.list_properties(), ["bar", "foo"])
+        self.assertEqual(set(frame.list_properties()), {"bar", "foo"})
 
     def test_distance(self):
         frame = Frame()

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import unittest
 import warnings
+import sys
 
 import chemfiles
 from chemfiles import Trajectory, ChemfilesError
@@ -12,7 +13,7 @@ class RemoveChemfilesWarnings(object):
         chemfiles.set_warnings_callback(lambda u: None)
 
     def __exit__(self, *args):
-        chemfiles.utils._set_default_warning_callback()
+        chemfiles.misc._set_default_warning_callback()
 
 
 remove_warnings = RemoveChemfilesWarnings()
@@ -20,8 +21,8 @@ remove_warnings = RemoveChemfilesWarnings()
 
 class TestErrors(unittest.TestCase):
     def test_last_error(self):
-        chemfiles.utils._clear_errors()
-        self.assertEqual(chemfiles.utils._last_error(), "")
+        chemfiles.misc._clear_errors()
+        self.assertEqual(chemfiles.misc._last_error(), "")
 
         try:
             with remove_warnings:
@@ -29,13 +30,13 @@ class TestErrors(unittest.TestCase):
         except ChemfilesError:
             pass
         self.assertEqual(
-            chemfiles.utils._last_error(),
+            chemfiles.misc._last_error(),
             "file at 'noextention' does not have an extension, provide a "
             "format name to read it",
         )
 
-        chemfiles.utils._clear_errors()
-        self.assertEqual(chemfiles.utils._last_error(), "")
+        chemfiles.misc._clear_errors()
+        self.assertEqual(chemfiles.misc._last_error(), "")
 
 
 LAST_MESSAGE = ""
@@ -60,7 +61,7 @@ class TestWarnings(unittest.TestCase):
             "format name to read it",
         )
 
-        chemfiles.utils._set_default_warning_callback()
+        chemfiles.misc._set_default_warning_callback()
 
     def test_warning_with_exception(self):
         def callback(message):
@@ -83,7 +84,7 @@ class TestWarnings(unittest.TestCase):
             "format name to read it",
         )
 
-        chemfiles.utils._set_default_warning_callback()
+        chemfiles.misc._set_default_warning_callback()
 
 
 if __name__ == "__main__":

--- a/tests/property.py
+++ b/tests/property.py
@@ -37,5 +37,5 @@ class TestProperty(unittest.TestCase):
         self.assertRaises(ChemfilesError, Property, ArithmeticError)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/residue.py
+++ b/tests/residue.py
@@ -5,6 +5,7 @@ import copy
 import numpy as np
 
 from chemfiles import Residue, ChemfilesError
+from utils import remove_warnings
 
 
 class TestResidue(unittest.TestCase):
@@ -26,7 +27,8 @@ class TestResidue(unittest.TestCase):
 
     def test_id(self):
         residue = Residue("bar")
-        self.assertRaises(ChemfilesError, residue.id)
+        with remove_warnings:
+            self.assertRaises(ChemfilesError, residue.id)
 
         residue = Residue("bar", 45)
         self.assertEqual(residue.id(), 45)

--- a/tests/residue.py
+++ b/tests/residue.py
@@ -53,6 +53,24 @@ class TestResidue(unittest.TestCase):
         self.assertTrue(3 in atoms)
         self.assertFalse(6 in atoms)
 
+    def test_property(self):
+        residue = Residue("ALA")
+
+        residue["foo"] = 3
+        self.assertEqual(residue["foo"], 3.0)
+
+        residue["foo"] = False
+        self.assertEqual(residue["foo"], False)
+
+        with remove_warnings:
+            with self.assertRaises(ChemfilesError):
+                _ = residue["bar"]
+
+        residue["bar"] = "baz"
+
+        self.assertEqual(residue.properties_count(), 2)
+        self.assertEqual(residue.list_properties(), ["bar", "foo"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/residue.py
+++ b/tests/residue.py
@@ -48,8 +48,9 @@ class TestResidue(unittest.TestCase):
 
         atoms = residue.atoms
         _ = atoms[0]
-        # Check for __contains__ with a cache
+        # Check the atomic cache
         self.assertTrue(atoms.indexes is not None)
+        self.assertEqual(len(atoms), 3)
         self.assertTrue(3 in atoms)
         self.assertFalse(6 in atoms)
 
@@ -65,6 +66,17 @@ class TestResidue(unittest.TestCase):
         with remove_warnings:
             with self.assertRaises(ChemfilesError):
                 _ = residue["bar"]
+
+            with self.assertRaises(ChemfilesError):
+                residue[3] = "test"
+
+            with self.assertRaises(ChemfilesError):
+                _ = residue[3]
+
+        # Check that enabling indexing/__getitem__ did not enable iteration
+        with self.assertRaises(TypeError):
+            for i in residue:
+                pass
 
         residue["bar"] = "baz"
 

--- a/tests/residue.py
+++ b/tests/residue.py
@@ -5,47 +5,53 @@ import copy
 import numpy as np
 
 from chemfiles import Residue, ChemfilesError
-from utils import remove_warnings
+from _utils import remove_warnings
 
 
 class TestResidue(unittest.TestCase):
     def test_copy(self):
         residue = Residue("bar")
-        residue.add_atom(7)
+        residue.atoms.append(7)
         cloned = copy.copy(residue)
 
-        self.assertEqual(residue.atoms_count(), 1)
-        self.assertEqual(cloned.atoms_count(), 1)
+        self.assertEqual(len(residue.atoms), 1)
+        self.assertEqual(len(cloned.atoms), 1)
 
-        residue.add_atom(2)
-        self.assertEqual(residue.atoms_count(), 2)
-        self.assertEqual(cloned.atoms_count(), 1)
+        residue.atoms.append(2)
+        self.assertEqual(len(residue.atoms), 2)
+        self.assertEqual(len(cloned.atoms), 1)
 
     def test_name(self):
         residue = Residue("bar")
-        self.assertEqual(residue.name(), "bar")
+        self.assertEqual(residue.name, "bar")
 
     def test_id(self):
         residue = Residue("bar")
         with remove_warnings:
-            self.assertRaises(ChemfilesError, residue.id)
+            with self.assertRaises(ChemfilesError):
+                _ = residue.id
 
         residue = Residue("bar", 45)
-        self.assertEqual(residue.id(), 45)
+        self.assertEqual(residue.id, 45)
 
     def test_atoms(self):
         residue = Residue("")
-        residue.add_atom(3)
-        residue.add_atom(4)
-        residue.add_atom(1)
+        residue.atoms.append(3)
+        residue.atoms.append(4)
+        residue.atoms.append(1)
 
-        self.assertEqual(residue.atoms_count(), 3)
-        self.assertEqual(len(residue), 3)
+        self.assertEqual(len(residue.atoms), 3)
+        self.assertTrue(3 in residue.atoms)
+        self.assertFalse(6 in residue.atoms)
 
-        self.assertTrue(residue.contains(3))
-        self.assertFalse(residue.contains(6))
+        self.assertEqual(list(residue.atoms), [1, 3, 4])
 
-        self.assertEqual(residue.atoms().all(), np.array([1, 3, 4]).all())
+        atoms = residue.atoms
+        _ = atoms[0]
+        # Check for __contains__ with a cache
+        self.assertTrue(atoms.indexes is not None)
+        self.assertTrue(3 in atoms)
+        self.assertFalse(6 in atoms)
 
 
 if __name__ == "__main__":

--- a/tests/residue.py
+++ b/tests/residue.py
@@ -13,41 +13,38 @@ class TestResidue(unittest.TestCase):
         residue.add_atom(7)
         cloned = copy.copy(residue)
 
-        self.assertEqual(residue.natoms(), 1)
-        self.assertEqual(cloned.natoms(), 1)
+        self.assertEqual(residue.atoms_count(), 1)
+        self.assertEqual(cloned.atoms_count(), 1)
 
         residue.add_atom(2)
-        self.assertEqual(residue.natoms(), 2)
-        self.assertEqual(cloned.natoms(), 1)
+        self.assertEqual(residue.atoms_count(), 2)
+        self.assertEqual(cloned.atoms_count(), 1)
 
     def test_name(self):
-        residue = Residue('bar')
-        self.assertEqual(residue.name(), 'bar')
+        residue = Residue("bar")
+        self.assertEqual(residue.name(), "bar")
 
     def test_id(self):
-        residue = Residue('bar')
+        residue = Residue("bar")
         self.assertRaises(ChemfilesError, residue.id)
 
-        residue = Residue('bar', 45)
+        residue = Residue("bar", 45)
         self.assertEqual(residue.id(), 45)
 
     def test_atoms(self):
-        residue = Residue('')
+        residue = Residue("")
         residue.add_atom(3)
         residue.add_atom(4)
         residue.add_atom(1)
 
-        self.assertEqual(residue.natoms(), 3)
+        self.assertEqual(residue.atoms_count(), 3)
         self.assertEqual(len(residue), 3)
 
         self.assertTrue(residue.contains(3))
         self.assertFalse(residue.contains(6))
 
-        self.assertEqual(
-            residue.atoms().all(),
-            np.array([1, 3, 4]).all()
-        )
+        self.assertEqual(residue.atoms().all(), np.array([1, 3, 4]).all())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/residue.py
+++ b/tests/residue.py
@@ -69,7 +69,7 @@ class TestResidue(unittest.TestCase):
         residue["bar"] = "baz"
 
         self.assertEqual(residue.properties_count(), 2)
-        self.assertEqual(residue.list_properties(), ["bar", "foo"])
+        self.assertEqual(set(residue.list_properties()), {"bar", "foo"})
 
 
 if __name__ == "__main__":

--- a/tests/selection.py
+++ b/tests/selection.py
@@ -7,20 +7,17 @@ from chemfiles import Selection, Topology, Frame, Atom
 
 
 def testing_frame():
-    topology = Topology()
-
-    topology.add_atom(Atom("H"))
-    topology.add_atom(Atom("O"))
-    topology.add_atom(Atom("O"))
-    topology.add_atom(Atom("H"))
-
-    topology.add_bond(0, 1)
-    topology.add_bond(1, 2)
-    topology.add_bond(2, 3)
-
     frame = Frame()
-    frame.resize(4)
-    frame.set_topology(topology)
+
+    frame.add_atom(Atom("H"), [0, 0, 0])
+    frame.add_atom(Atom("O"), [0, 0, 0])
+    frame.add_atom(Atom("O"), [0, 0, 0])
+    frame.add_atom(Atom("H"), [0, 0, 0])
+
+    frame.add_bond(0, 1)
+    frame.add_bond(1, 2)
+    frame.add_bond(2, 3)
+
     return frame
 
 
@@ -31,12 +28,12 @@ class TestSelection(unittest.TestCase):
         copy.copy(selection)
 
     def test_size(self):
-        self.assertEqual(Selection("name H").size(), 1)
-        self.assertEqual(Selection("pairs: all").size(), 2)
-        self.assertEqual(Selection("dihedrals: all").size(), 4)
+        self.assertEqual(Selection("name H").size, 1)
+        self.assertEqual(Selection("pairs: all").size, 2)
+        self.assertEqual(Selection("dihedrals: all").size, 4)
 
     def test_string(self):
-        self.assertEqual(Selection("name H").string(), "name H")
+        self.assertEqual(Selection("name H").string, "name H")
 
     def test_evaluate(self):
         frame = testing_frame()

--- a/tests/selection.py
+++ b/tests/selection.py
@@ -64,5 +64,5 @@ class TestSelection(unittest.TestCase):
         self.assertEqual([(0, 1, 2, 3)], res)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/topology.py
+++ b/tests/topology.py
@@ -174,6 +174,14 @@ class TestTopology(unittest.TestCase):
             self.assertEqual(atom.name, "")
         self.assertEqual(i, 5)
 
+        topology.residues.append(Residue("foo"))
+        topology.residues.append(Residue("foo"))
+        topology.residues.append(Residue("foo"))
+
+        for i, residue in enumerate(topology.residues):
+            self.assertEqual(residue.name, "foo")
+        self.assertEqual(i, 2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/topology.py
+++ b/tests/topology.py
@@ -13,17 +13,17 @@ class TestTopology(unittest.TestCase):
         topology.resize(4)
         cloned = copy.copy(topology)
 
-        self.assertEqual(topology.natoms(), 4)
-        self.assertEqual(cloned.natoms(), 4)
+        self.assertEqual(topology.atoms_count(), 4)
+        self.assertEqual(cloned.atoms_count(), 4)
 
         topology.resize(8)
-        self.assertEqual(topology.natoms(), 8)
-        self.assertEqual(cloned.natoms(), 4)
+        self.assertEqual(topology.atoms_count(), 8)
+        self.assertEqual(cloned.atoms_count(), 4)
 
     def test_size(self):
         topology = Topology()
 
-        self.assertEqual(topology.natoms(), 0)
+        self.assertEqual(topology.atoms_count(), 0)
         self.assertEqual(len(topology), 0)
 
         topology.add_atom(Atom("H"))

--- a/tests/topology.py
+++ b/tests/topology.py
@@ -13,30 +13,32 @@ class TestTopology(unittest.TestCase):
         topology.resize(4)
         cloned = copy.copy(topology)
 
-        self.assertEqual(topology.atoms_count(), 4)
-        self.assertEqual(cloned.atoms_count(), 4)
+        self.assertEqual(len(topology.atoms), 4)
+        self.assertEqual(len(cloned.atoms), 4)
 
         topology.resize(8)
-        self.assertEqual(topology.atoms_count(), 8)
-        self.assertEqual(cloned.atoms_count(), 4)
+        self.assertEqual(len(topology.atoms), 8)
+        self.assertEqual(len(cloned.atoms), 4)
 
     def test_size(self):
         topology = Topology()
 
-        self.assertEqual(topology.atoms_count(), 0)
-        self.assertEqual(len(topology), 0)
+        self.assertEqual(len(topology.atoms), 0)
 
-        topology.add_atom(Atom("H"))
-        topology.add_atom(Atom("O"))
-        topology.add_atom(Atom("O"))
-        topology.add_atom(Atom("H"))
+        topology.atoms.append(Atom("H"))
+        topology.atoms.append(Atom("O"))
+        topology.atoms.append(Atom("O"))
+        topology.atoms.append(Atom("H"))
 
-        self.assertEqual(len(topology), 4)
+        self.assertEqual(len(topology.atoms), 4)
         topology.resize(8)
-        self.assertEqual(len(topology), 8)
+        self.assertEqual(len(topology.atoms), 8)
 
-        topology.remove(3)
-        self.assertEqual(len(topology), 7)
+        topology.atoms.remove(3)
+        self.assertEqual(len(topology.atoms), 7)
+
+        del topology.atoms[4]
+        self.assertEqual(len(topology.atoms), 6)
 
     def test_bonding(self):
         topology = Topology()
@@ -55,17 +57,17 @@ class TestTopology(unittest.TestCase):
         self.assertEqual(topology.impropers_count(), 0)
 
         self.assertEqual(
-            topology.bonds().all(),
+            topology.bonds.all(),
             np.array([[2, 3], [1, 2], [0, 1]]).all()
         )
 
         self.assertEqual(
-            topology.angles().all(),
+            topology.angles.all(),
             np.array([[0, 1, 2], [1, 2, 3]]).all()
         )
 
         self.assertEqual(
-            topology.dihedrals().all(),
+            topology.dihedrals.all(),
             np.array([[0, 1, 2, 3]]).all()
         )
 
@@ -82,7 +84,7 @@ class TestTopology(unittest.TestCase):
         self.assertEqual(topology.impropers_count(), 1)
 
         self.assertEqual(
-            topology.impropers().all(),
+            topology.impropers.all(),
             np.array([[0, 1, 2, 3]]).all()
         )
 
@@ -91,38 +93,43 @@ class TestTopology(unittest.TestCase):
         topology.resize(4)
 
         residue = Residue("")
-        residue.add_atom(1)
-        topology.add_residue(residue)
+        residue.atoms.append(1)
+        topology.residues.append(residue)
 
-        topology.atom(2)
-        topology.residue(0)
-        topology.residue_for_atom(1)
+        _ = topology.atoms[2]
+        _ = topology.residues[0]
+        _ = topology.residue_for_atom(1)
 
-        self.assertRaises(IndexError, topology.atom, 6)
-        self.assertRaises(IndexError, topology.residue, 6)
-        self.assertRaises(IndexError, topology.residue_for_atom, 6)
+        with self.assertRaises(IndexError):
+            _ = topology.atoms[6]
+
+        with self.assertRaises(IndexError):
+            _ = topology.residues[6]
+
+        with self.assertRaises(IndexError):
+            _ = topology.residue_for_atom(6)
 
     def test_residues(self):
         topology = Topology()
         topology.resize(6)
 
         residue = Residue('foo', 4)
-        residue.add_atom(3)
-        residue.add_atom(4)
-        topology.add_residue(residue)
+        residue.atoms.append(3)
+        residue.atoms.append(4)
+        topology.residues.append(residue)
 
         residue = Residue('bar', 67)
-        residue.add_atom(1)
-        residue.add_atom(2)
-        topology.add_residue(residue)
+        residue.atoms.append(1)
+        residue.atoms.append(2)
+        topology.residues.append(residue)
 
         self.assertEqual(topology.residue_for_atom(5), None)
 
-        first = topology.residue(0)
-        self.assertEqual(first.name(), 'foo')
+        first = topology.residues[0]
+        self.assertEqual(first.name, 'foo')
 
-        second = topology.residue(1)
-        self.assertEqual(second.name(), 'bar')
+        second = topology.residues[1]
+        self.assertEqual(second.name, 'bar')
 
         self.assertFalse(topology.residues_linked(first, second))
 
@@ -133,11 +140,9 @@ class TestTopology(unittest.TestCase):
         topology = Topology()
         topology.resize(6)
 
-        i = 0
-        for atom in topology:
-            self.assertEqual(atom.name(), "")
-            i += 1
-        self.assertEqual(i, 6)
+        for i, atom in enumerate(topology.atoms):
+            self.assertEqual(atom.name, "")
+        self.assertEqual(i, 5)
 
 
 if __name__ == '__main__':

--- a/tests/trajectory.py
+++ b/tests/trajectory.py
@@ -8,6 +8,8 @@ from ctypes import ArgumentError
 from chemfiles import Trajectory, Topology, Frame, UnitCell, Atom
 from chemfiles import ChemfilesError
 
+from utils import remove_warnings
+
 
 def get_data_path(data):
     root = os.path.dirname(__file__)
@@ -16,13 +18,14 @@ def get_data_path(data):
 
 class TestTrajectory(unittest.TestCase):
     def test_errors(self):
-        self.assertRaises(ChemfilesError, Trajectory, get_data_path("not-here.xyz"))
-        self.assertRaises(ChemfilesError, Trajectory, get_data_path("empty.unknown"))
+        with remove_warnings:
+            self.assertRaises(ChemfilesError, Trajectory, get_data_path("not-here.xyz"))
+            self.assertRaises(ChemfilesError, Trajectory, get_data_path("empty.unknown"))
 
-        with Trajectory("test-tmp.xyz", "w") as trajectory:
-            self.assertRaises(ArgumentError, trajectory.write, None)
+            with Trajectory("test-tmp.xyz", "w") as trajectory:
+                self.assertRaises(ArgumentError, trajectory.write, None)
 
-        os.unlink("test-tmp.xyz")
+            os.unlink("test-tmp.xyz")
 
     def test_read(self):
         trajectory = Trajectory(get_data_path("water.xyz"))

--- a/tests/trajectory.py
+++ b/tests/trajectory.py
@@ -38,10 +38,12 @@ class TestTrajectory(unittest.TestCase):
         self.assertEqual(len(frame.atoms), 297)
 
         self.assertEqual(
-            frame.positions[0].all(), np.array([0.417219, 8.303366, 11.737172]).all()
+            frame.positions[0].all(),
+            np.array([0.417219, 8.303366, 11.737172]).all()
         )
         self.assertEqual(
-            frame.positions[124].all(), np.array([5.099554, -0.045104, 14.153846]).all()
+            frame.positions[124].all(),
+            np.array([5.099554, -0.045104, 14.153846]).all()
         )
 
         self.assertEqual(len(frame.atoms), 297)
@@ -53,10 +55,12 @@ class TestTrajectory(unittest.TestCase):
         self.assertEqual(frame.cell.lengths, (30.0, 30.0, 30.0))
 
         self.assertEqual(
-            frame.positions[0].all(), np.array([0.761277, 8.106125, 10.622949]).all()
+            frame.positions[0].all(),
+            np.array([0.761277, 8.106125, 10.622949]).all()
         )
         self.assertEqual(
-            frame.positions[124].all(), np.array([5.13242, 0.079862, 14.194161]).all()
+            frame.positions[124].all(),
+            np.array([5.13242, 0.079862, 14.194161]).all()
         )
 
         self.assertEqual(len(frame.atoms), 297)

--- a/tests/trajectory.py
+++ b/tests/trajectory.py
@@ -31,6 +31,7 @@ class TestTrajectory(unittest.TestCase):
         trajectory = Trajectory(get_data_path("water.xyz"))
 
         self.assertEqual(trajectory.nsteps, 100)
+        self.assertEqual(trajectory.path, get_data_path("water.xyz"))
 
         frame = Frame()
         trajectory.read(frame)

--- a/tests/trajectory.py
+++ b/tests/trajectory.py
@@ -8,7 +8,7 @@ from ctypes import ArgumentError
 from chemfiles import Trajectory, Topology, Frame, UnitCell, Atom
 from chemfiles import ChemfilesError
 
-from utils import remove_warnings
+from _utils import remove_warnings
 
 
 def get_data_path(data):
@@ -30,62 +30,57 @@ class TestTrajectory(unittest.TestCase):
     def test_read(self):
         trajectory = Trajectory(get_data_path("water.xyz"))
 
-        self.assertEqual(trajectory.nsteps(), 100)
+        self.assertEqual(trajectory.nsteps, 100)
 
         frame = Frame()
         trajectory.read(frame)
-        self.assertEqual(frame.atoms_count(), 297)
+        self.assertEqual(len(frame.atoms), 297)
 
-        positions = frame.positions()
         self.assertEqual(
-            positions[0].all(), np.array([0.417219, 8.303366, 11.737172]).all()
+            frame.positions[0].all(), np.array([0.417219, 8.303366, 11.737172]).all()
         )
         self.assertEqual(
-            positions[124].all(), np.array([5.099554, -0.045104, 14.153846]).all()
+            frame.positions[124].all(), np.array([5.099554, -0.045104, 14.153846]).all()
         )
 
-        topology = frame.topology()
-        self.assertEqual(topology.atoms_count(), 297)
-        self.assertEqual(topology.atom(0).name(), "O")
-        self.assertEqual(topology.atom(1).name(), "H")
+        self.assertEqual(len(frame.atoms), 297)
+        self.assertEqual(frame.atoms[0].name, "O")
+        self.assertEqual(frame.atoms[1].name, "H")
 
         trajectory.set_cell(UnitCell(30, 30, 30))
         trajectory.read_step(41, frame)
-        self.assertEqual(frame.cell().lengths(), (30.0, 30.0, 30.0))
+        self.assertEqual(frame.cell.lengths, (30.0, 30.0, 30.0))
 
-        positions = frame.positions()
         self.assertEqual(
-            positions[0].all(), np.array([0.761277, 8.106125, 10.622949]).all()
+            frame.positions[0].all(), np.array([0.761277, 8.106125, 10.622949]).all()
         )
         self.assertEqual(
-            positions[124].all(), np.array([5.13242, 0.079862, 14.194161]).all()
+            frame.positions[124].all(), np.array([5.13242, 0.079862, 14.194161]).all()
         )
 
-        topology = frame.topology()
-        self.assertEqual(topology.atoms_count(), 297)
-        self.assertEqual(topology.bonds_count(), 0)
+        self.assertEqual(len(frame.atoms), 297)
+        self.assertEqual(frame.topology.bonds_count(), 0)
 
         frame.guess_bonds()
-        topology = frame.topology()
-        self.assertEqual(topology.bonds_count(), 181)
-        self.assertEqual(topology.angles_count(), 87)
+        self.assertEqual(frame.topology.bonds_count(), 181)
+        self.assertEqual(frame.topology.angles_count(), 87)
 
         topology = Topology()
         for i in range(297):
-            topology.add_atom(Atom("Cs"))
+            topology.atoms.append(Atom("Cs"))
 
         trajectory.set_topology(topology)
         frame = trajectory.read_step(10)
-        self.assertEqual(frame.atom(10).name(), "Cs")
+        self.assertEqual(frame.atoms[10].name, "Cs")
 
         trajectory.set_topology(get_data_path("topology.xyz"), "XYZ")
         frame = trajectory.read()
-        self.assertEqual(frame.atom(100).name(), "Rd")
+        self.assertEqual(frame.atoms[100].name, "Rd")
 
     def test_protocols(self):
         with Trajectory(get_data_path("water.xyz")) as trajectory:
             for frame in trajectory:
-                self.assertEqual(frame.atoms_count(), 297)
+                self.assertEqual(len(frame.atoms), 297)
 
     def test_close(self):
         trajectory = Trajectory(get_data_path("water.xyz"))
@@ -94,14 +89,9 @@ class TestTrajectory(unittest.TestCase):
 
     def test_write(self):
         frame = Frame()
-        frame.resize(4)
-        positions = frame.positions()
-        topology = Topology()
         for i in range(4):
-            positions[i] = [1, 2, 3]
-            topology.add_atom(Atom("X"))
+            frame.add_atom(Atom("X"), [1, 2, 3])
 
-        frame.set_topology(topology)
         with Trajectory("test-tmp.xyz", "w") as fd:
             fd.write(frame)
 

--- a/tests/trajectory.py
+++ b/tests/trajectory.py
@@ -16,12 +16,8 @@ def get_data_path(data):
 
 class TestTrajectory(unittest.TestCase):
     def test_errors(self):
-        self.assertRaises(
-            ChemfilesError, Trajectory, get_data_path("not-here.xyz")
-        )
-        self.assertRaises(
-            ChemfilesError, Trajectory, get_data_path("empty.unknown")
-        )
+        self.assertRaises(ChemfilesError, Trajectory, get_data_path("not-here.xyz"))
+        self.assertRaises(ChemfilesError, Trajectory, get_data_path("empty.unknown"))
 
         with Trajectory("test-tmp.xyz", "w") as trajectory:
             self.assertRaises(ArgumentError, trajectory.write, None)
@@ -35,20 +31,18 @@ class TestTrajectory(unittest.TestCase):
 
         frame = Frame()
         trajectory.read(frame)
-        self.assertEqual(frame.natoms(), 297)
+        self.assertEqual(frame.atoms_count(), 297)
 
         positions = frame.positions()
         self.assertEqual(
-            positions[0].all(),
-            np.array([0.417219, 8.303366, 11.737172]).all()
+            positions[0].all(), np.array([0.417219, 8.303366, 11.737172]).all()
         )
         self.assertEqual(
-            positions[124].all(),
-            np.array([5.099554, -0.045104, 14.153846]).all()
+            positions[124].all(), np.array([5.099554, -0.045104, 14.153846]).all()
         )
 
         topology = frame.topology()
-        self.assertEqual(topology.natoms(), 297)
+        self.assertEqual(topology.atoms_count(), 297)
         self.assertEqual(topology.atom(0).name(), "O")
         self.assertEqual(topology.atom(1).name(), "H")
 
@@ -58,19 +52,17 @@ class TestTrajectory(unittest.TestCase):
 
         positions = frame.positions()
         self.assertEqual(
-            positions[0].all(),
-            np.array([0.761277, 8.106125, 10.622949]).all()
+            positions[0].all(), np.array([0.761277, 8.106125, 10.622949]).all()
         )
         self.assertEqual(
-            positions[124].all(),
-            np.array([5.13242, 0.079862, 14.194161]).all()
+            positions[124].all(), np.array([5.13242, 0.079862, 14.194161]).all()
         )
 
         topology = frame.topology()
-        self.assertEqual(topology.natoms(), 297)
+        self.assertEqual(topology.atoms_count(), 297)
         self.assertEqual(topology.bonds_count(), 0)
 
-        frame.guess_topology()
+        frame.guess_bonds()
         topology = frame.topology()
         self.assertEqual(topology.bonds_count(), 181)
         self.assertEqual(topology.angles_count(), 87)
@@ -90,7 +82,7 @@ class TestTrajectory(unittest.TestCase):
     def test_protocols(self):
         with Trajectory(get_data_path("water.xyz")) as trajectory:
             for frame in trajectory:
-                self.assertEqual(frame.natoms(), 297)
+                self.assertEqual(frame.atoms_count(), 297)
 
     def test_close(self):
         trajectory = Trajectory(get_data_path("water.xyz"))
@@ -123,5 +115,5 @@ X 1 2 3
         os.unlink("test-tmp.xyz")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,21 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 import unittest
+import warnings
 
 import chemfiles
 from chemfiles import Trajectory, ChemfilesError
+
+
+class RemoveChemfilesWarnings(object):
+    def __enter__(self):
+        chemfiles.set_warnings_callback(lambda u: None)
+
+    def __exit__(self, *args):
+        chemfiles.utils._set_default_warning_callback()
+
+
+remove_warnings = RemoveChemfilesWarnings()
 
 
 class TestErrors(unittest.TestCase):
@@ -12,7 +24,8 @@ class TestErrors(unittest.TestCase):
         self.assertEqual(chemfiles.utils._last_error(), "")
 
         try:
-            Trajectory("noextention")
+            with remove_warnings:
+                Trajectory("noextention")
         except ChemfilesError:
             pass
         self.assertEqual(
@@ -47,6 +60,8 @@ class TestWarnings(unittest.TestCase):
             "format name to read it",
         )
 
+        chemfiles.utils._set_default_warning_callback()
+
     def test_warning_with_exception(self):
         def callback(message):
             global LAST_MESSAGE
@@ -55,10 +70,12 @@ class TestWarnings(unittest.TestCase):
 
         chemfiles.set_warnings_callback(callback)
 
-        try:
-            Trajectory("noextention")
-        except ChemfilesError:
-            pass
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            try:
+                Trajectory("noextention")
+            except ChemfilesError:
+                pass
 
         self.assertEqual(
             LAST_MESSAGE,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@ class TestErrors(unittest.TestCase):
         self.assertEqual(
             chemfiles.utils._last_error(),
             "file at 'noextention' does not have an extension, provide a "
-            "format name to read it"
+            "format name to read it",
         )
 
         chemfiles.utils._clear_errors()
@@ -44,14 +44,14 @@ class TestWarnings(unittest.TestCase):
         self.assertEqual(
             LAST_MESSAGE,
             "file at 'noextention' does not have an extension, provide a "
-            "format name to read it"
+            "format name to read it",
         )
 
     def test_warning_with_exception(self):
         def callback(message):
             global LAST_MESSAGE
             LAST_MESSAGE = message
-            raise Exception(message)
+            raise Exception("test exception in callback")
 
         chemfiles.set_warnings_callback(callback)
 
@@ -63,9 +63,11 @@ class TestWarnings(unittest.TestCase):
         self.assertEqual(
             LAST_MESSAGE,
             "file at 'noextention' does not have an extension, provide a "
-            "format name to read it"
+            "format name to read it",
         )
 
+        chemfiles.utils._set_default_warning_callback()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 
 [testenv]
 commands =
-    python setup.py install --quiet --build-type=Debug -- -DCHFL_PY_INTERNAL_CHEMFILES=ON
+    python setup.py --quiet install -- -DCHFL_PY_INTERNAL_CHEMFILES=ON
     discover -p "*.py" tests
 deps =
     discover

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 skipsdist = True
+
 [testenv]
 commands =
-    python setup.py install --quiet -- -DCHFL_PY_INTERNAL_CHEMFILES=ON
+    python setup.py install --quiet --build-type=Debug -- -DCHFL_PY_INTERNAL_CHEMFILES=ON
     discover -p "*.py" tests
 deps =
     discover


### PR DESCRIPTION
In addition to an update to 0.9, this PR contains a few changes of the API (660089f5d84923cd7155bd6aabc39b6c180537ed) I would like to discuss.

Previously, in order to change the name of an atom in a frame, one had to write the following:

```python
topology = frame.topology()
new_topology = Topology()

for atom in topology:
    atom.set_name("Fe")
    new_topology.add_atom(atom)

frame.set_topology(topology)
```

Where every function call is making a copy. The introduction of the shared allocator on the C++ side, and the use of `@property` on Python side allow to write the same code like this:

```python
for atom in frame:
    atom.name = "Fe"
```

In the same spirit, accessing all the bonds in the system is now `frame.topology.bonds` instead of `frame.topology().bonds()`.

Do you think these changes are worthwile? I think this makes the API more Python-like, at the cost of making it a bit more different from the other languages.
