### PR TITLE
Don't leak all the memory, and respect constness

### DIFF
--- a/chemfiles/_utils.py
+++ b/chemfiles/_utils.py
@@ -15,18 +15,17 @@ else:
 
 class CxxPointer(object):
     __frozen = False
+    __ptr = 0
 
     def __init__(self, ptr, is_const=True):
-        _check_handle(ptr)
         self.__ptr = ptr
         self.__is_const = is_const
-        self._as_parameter_ = self.__ptr
         self.__frozen = True
+        _check_handle(ptr)
 
     def __del__(self):
         """Free the memory associated with this instance"""
-        if hasattr(self, "__ptr"):
-            self.ffi.chfl_free(self)
+        self.ffi.chfl_free(self)
 
     def __setattr__(self, key, value):
         if self.__frozen and not hasattr(self, key):
@@ -48,6 +47,11 @@ class CxxPointer(object):
         new = cls.__new__(cls)
         super(cls, new).__init__(ptr, is_const=True)
         return new
+
+    @property
+    def _as_parameter_(self):
+        """used by ctypes when passing self as parameter to a FFI function"""
+        return self.const_ptr
 
     @property
     def ptr(self):

--- a/chemfiles/cell.py
+++ b/chemfiles/cell.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from ctypes import c_double, ARRAY
 from enum import IntEnum
 
-from ._utils import CxxPointer
+from .utils import CxxPointer
 from .ffi import chfl_cellshape, chfl_vector3d
 
 
@@ -60,7 +60,7 @@ class UnitCell(CxxPointer):
         super(UnitCell, self).__init__(ptr, is_const=False)
 
     def __copy__(self):
-        return UnitCell.from_ptr(self.ffi.chfl_cell_copy(self))
+        return UnitCell.from_mutable_ptr(self.ffi.chfl_cell_copy(self.ptr))
 
     def __repr__(self):
         return "UnitCell({}, {}, {}, {}, {}, {})".format(*(self.lengths + self.angles))
@@ -69,7 +69,7 @@ class UnitCell(CxxPointer):
     def lengths(self):
         """Get the three lenghts of this :py:class:`UnitCell`, in Angstroms."""
         lengths = chfl_vector3d(0, 0, 0)
-        self.ffi.chfl_cell_lengths(self, lengths)
+        self.ffi.chfl_cell_lengths(self.ptr, lengths)
         return lengths[0], lengths[1], lengths[2]
 
     @lengths.setter
@@ -79,13 +79,13 @@ class UnitCell(CxxPointer):
         values should be in Angstroms.
         """
         a, b, c = lengths
-        self.ffi.chfl_cell_set_lengths(self, chfl_vector3d(a, b, c))
+        self.ffi.chfl_cell_set_lengths(self.mut_ptr, chfl_vector3d(a, b, c))
 
     @property
     def angles(self):
         """Get the three angles of this :py:class:`UnitCell`, in degrees."""
         angles = chfl_vector3d(0, 0, 0)
-        self.ffi.chfl_cell_angles(self, angles)
+        self.ffi.chfl_cell_angles(self.ptr, angles)
         return angles[0], angles[1], angles[2]
 
     @angles.setter
@@ -96,7 +96,7 @@ class UnitCell(CxxPointer):
         angles is only possible for ``CellShape.Triclinic`` cells.
         """
         alpha, beta, gamma = angles
-        self.ffi.chfl_cell_set_angles(self, chfl_vector3d(alpha, beta, gamma))
+        self.ffi.chfl_cell_set_angles(self.mut_ptr, chfl_vector3d(alpha, beta, gamma))
 
     @property
     def matrix(self):
@@ -114,7 +114,7 @@ class UnitCell(CxxPointer):
             |  0     0    c_z |
         """
         m = ARRAY(chfl_vector3d, 3)()
-        self.ffi.chfl_cell_matrix(self, m)
+        self.ffi.chfl_cell_matrix(self.ptr, m)
         return [
             (m[0][0], m[0][1], m[0][2]),
             (m[1][0], m[1][1], m[1][2]),
@@ -125,19 +125,19 @@ class UnitCell(CxxPointer):
     def shape(self):
         """Get the shape of this :py:class:`UnitCell`."""
         shape = chfl_cellshape()
-        self.ffi.chfl_cell_shape(self, shape)
+        self.ffi.chfl_cell_shape(self.ptr, shape)
         return CellShape(shape.value)
 
     @shape.setter
     def shape(self, shape):
         """Set the shape of this :py:class:`UnitCell` to ``shape``."""
-        self.ffi.chfl_cell_set_shape(self, chfl_cellshape(shape))
+        self.ffi.chfl_cell_set_shape(self.mut_ptr, chfl_cellshape(shape))
 
     @property
     def volume(self):
         """Get the volume of this :py:class:`UnitCell`."""
         volume = c_double()
-        self.ffi.chfl_cell_volume(self, volume)
+        self.ffi.chfl_cell_volume(self.ptr, volume)
         return volume.value
 
     def wrap(self, vector):
@@ -146,5 +146,5 @@ class UnitCell(CxxPointer):
         vector.
         """
         vector = chfl_vector3d(vector[0], vector[1], vector[2])
-        self.ffi.chfl_cell_wrap(self, vector)
+        self.ffi.chfl_cell_wrap(self.ptr, vector)
         return (vector[0], vector[1], vector[2])

--- a/chemfiles/ffi.py
+++ b/chemfiles/ffi.py
@@ -17,7 +17,7 @@ import numpy as np
 from ctypes import c_int, c_uint64, c_double, c_char, c_char_p, c_void_p, c_bool
 from ctypes import CFUNCTYPE, ARRAY, POINTER, Structure
 
-from ._utils import _check_return_code
+from .utils import _check_return_code
 
 
 class chfl_status(c_int):
@@ -104,19 +104,9 @@ class chfl_match(Structure):
 
 
 def set_interface(c_lib):
-    from chemfiles import Atom
-    from chemfiles import Residue
-    from chemfiles import Topology
-    from chemfiles import UnitCell
-    from chemfiles import Frame
-    from chemfiles import Selection
-    from chemfiles import Trajectory
-
-    from chemfiles import Property
-
     # Manually defined functions
     c_lib.chfl_free.argtypes = [c_void_p]
-    c_lib.chfl_trajectory_close.argtypes = [Trajectory]
+    c_lib.chfl_trajectory_close.argtypes = [POINTER(CHFL_TRAJECTORY)]
     # End of manually defined functions
 
     # Function "chfl_version", at types.h:145
@@ -159,27 +149,27 @@ def set_interface(c_lib):
     c_lib.chfl_property_vector3d.restype = POINTER(CHFL_PROPERTY)
 
     # Function "chfl_property_get_kind", at property.h:69
-    c_lib.chfl_property_get_kind.argtypes = [Property, POINTER(chfl_property_kind)]
+    c_lib.chfl_property_get_kind.argtypes = [POINTER(CHFL_PROPERTY), POINTER(chfl_property_kind)]
     c_lib.chfl_property_get_kind.restype = chfl_status
     c_lib.chfl_property_get_kind.errcheck = _check_return_code
 
     # Function "chfl_property_get_bool", at property.h:82
-    c_lib.chfl_property_get_bool.argtypes = [Property, POINTER(c_bool)]
+    c_lib.chfl_property_get_bool.argtypes = [POINTER(CHFL_PROPERTY), POINTER(c_bool)]
     c_lib.chfl_property_get_bool.restype = chfl_status
     c_lib.chfl_property_get_bool.errcheck = _check_return_code
 
     # Function "chfl_property_get_double", at property.h:95
-    c_lib.chfl_property_get_double.argtypes = [Property, POINTER(c_double)]
+    c_lib.chfl_property_get_double.argtypes = [POINTER(CHFL_PROPERTY), POINTER(c_double)]
     c_lib.chfl_property_get_double.restype = chfl_status
     c_lib.chfl_property_get_double.errcheck = _check_return_code
 
     # Function "chfl_property_get_string", at property.h:110
-    c_lib.chfl_property_get_string.argtypes = [Property, c_char_p, c_uint64]
+    c_lib.chfl_property_get_string.argtypes = [POINTER(CHFL_PROPERTY), c_char_p, c_uint64]
     c_lib.chfl_property_get_string.restype = chfl_status
     c_lib.chfl_property_get_string.errcheck = _check_return_code
 
     # Function "chfl_property_get_vector3d", at property.h:123
-    c_lib.chfl_property_get_vector3d.argtypes = [Property, chfl_vector3d]
+    c_lib.chfl_property_get_vector3d.argtypes = [POINTER(CHFL_PROPERTY), chfl_vector3d]
     c_lib.chfl_property_get_vector3d.restype = chfl_status
     c_lib.chfl_property_get_vector3d.errcheck = _check_return_code
 
@@ -188,94 +178,94 @@ def set_interface(c_lib):
     c_lib.chfl_atom.restype = POINTER(CHFL_ATOM)
 
     # Function "chfl_atom_copy", at atom.h:30
-    c_lib.chfl_atom_copy.argtypes = [Atom]
+    c_lib.chfl_atom_copy.argtypes = [POINTER(CHFL_ATOM)]
     c_lib.chfl_atom_copy.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_from_frame", at atom.h:54
-    c_lib.chfl_atom_from_frame.argtypes = [Frame, c_uint64]
+    # Function "chfl_atom_from_frame", at atom.h:56
+    c_lib.chfl_atom_from_frame.argtypes = [POINTER(CHFL_FRAME), c_uint64]
     c_lib.chfl_atom_from_frame.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_from_topology", at atom.h:77
-    c_lib.chfl_atom_from_topology.argtypes = [Topology, c_uint64]
+    # Function "chfl_atom_from_topology", at atom.h:79
+    c_lib.chfl_atom_from_topology.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64]
     c_lib.chfl_atom_from_topology.restype = POINTER(CHFL_ATOM)
 
-    # Function "chfl_atom_mass", at atom.h:88
-    c_lib.chfl_atom_mass.argtypes = [Atom, POINTER(c_double)]
+    # Function "chfl_atom_mass", at atom.h:90
+    c_lib.chfl_atom_mass.argtypes = [POINTER(CHFL_ATOM), POINTER(c_double)]
     c_lib.chfl_atom_mass.restype = chfl_status
     c_lib.chfl_atom_mass.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_mass", at atom.h:97
-    c_lib.chfl_atom_set_mass.argtypes = [Atom, c_double]
+    # Function "chfl_atom_set_mass", at atom.h:99
+    c_lib.chfl_atom_set_mass.argtypes = [POINTER(CHFL_ATOM), c_double]
     c_lib.chfl_atom_set_mass.restype = chfl_status
     c_lib.chfl_atom_set_mass.errcheck = _check_return_code
 
-    # Function "chfl_atom_charge", at atom.h:106
-    c_lib.chfl_atom_charge.argtypes = [Atom, POINTER(c_double)]
+    # Function "chfl_atom_charge", at atom.h:108
+    c_lib.chfl_atom_charge.argtypes = [POINTER(CHFL_ATOM), POINTER(c_double)]
     c_lib.chfl_atom_charge.restype = chfl_status
     c_lib.chfl_atom_charge.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_charge", at atom.h:115
-    c_lib.chfl_atom_set_charge.argtypes = [Atom, c_double]
+    # Function "chfl_atom_set_charge", at atom.h:117
+    c_lib.chfl_atom_set_charge.argtypes = [POINTER(CHFL_ATOM), c_double]
     c_lib.chfl_atom_set_charge.restype = chfl_status
     c_lib.chfl_atom_set_charge.errcheck = _check_return_code
 
-    # Function "chfl_atom_type", at atom.h:125
-    c_lib.chfl_atom_type.argtypes = [Atom, c_char_p, c_uint64]
+    # Function "chfl_atom_type", at atom.h:127
+    c_lib.chfl_atom_type.argtypes = [POINTER(CHFL_ATOM), c_char_p, c_uint64]
     c_lib.chfl_atom_type.restype = chfl_status
     c_lib.chfl_atom_type.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_type", at atom.h:136
-    c_lib.chfl_atom_set_type.argtypes = [Atom, c_char_p]
+    # Function "chfl_atom_set_type", at atom.h:138
+    c_lib.chfl_atom_set_type.argtypes = [POINTER(CHFL_ATOM), c_char_p]
     c_lib.chfl_atom_set_type.restype = chfl_status
     c_lib.chfl_atom_set_type.errcheck = _check_return_code
 
-    # Function "chfl_atom_name", at atom.h:146
-    c_lib.chfl_atom_name.argtypes = [Atom, c_char_p, c_uint64]
+    # Function "chfl_atom_name", at atom.h:148
+    c_lib.chfl_atom_name.argtypes = [POINTER(CHFL_ATOM), c_char_p, c_uint64]
     c_lib.chfl_atom_name.restype = chfl_status
     c_lib.chfl_atom_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_name", at atom.h:157
-    c_lib.chfl_atom_set_name.argtypes = [Atom, c_char_p]
+    # Function "chfl_atom_set_name", at atom.h:159
+    c_lib.chfl_atom_set_name.argtypes = [POINTER(CHFL_ATOM), c_char_p]
     c_lib.chfl_atom_set_name.restype = chfl_status
     c_lib.chfl_atom_set_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_full_name", at atom.h:167
-    c_lib.chfl_atom_full_name.argtypes = [Atom, c_char_p, c_uint64]
+    # Function "chfl_atom_full_name", at atom.h:169
+    c_lib.chfl_atom_full_name.argtypes = [POINTER(CHFL_ATOM), c_char_p, c_uint64]
     c_lib.chfl_atom_full_name.restype = chfl_status
     c_lib.chfl_atom_full_name.errcheck = _check_return_code
 
-    # Function "chfl_atom_vdw_radius", at atom.h:179
-    c_lib.chfl_atom_vdw_radius.argtypes = [Atom, POINTER(c_double)]
+    # Function "chfl_atom_vdw_radius", at atom.h:181
+    c_lib.chfl_atom_vdw_radius.argtypes = [POINTER(CHFL_ATOM), POINTER(c_double)]
     c_lib.chfl_atom_vdw_radius.restype = chfl_status
     c_lib.chfl_atom_vdw_radius.errcheck = _check_return_code
 
-    # Function "chfl_atom_covalent_radius", at atom.h:189
-    c_lib.chfl_atom_covalent_radius.argtypes = [Atom, POINTER(c_double)]
+    # Function "chfl_atom_covalent_radius", at atom.h:191
+    c_lib.chfl_atom_covalent_radius.argtypes = [POINTER(CHFL_ATOM), POINTER(c_double)]
     c_lib.chfl_atom_covalent_radius.restype = chfl_status
     c_lib.chfl_atom_covalent_radius.errcheck = _check_return_code
 
-    # Function "chfl_atom_atomic_number", at atom.h:199
-    c_lib.chfl_atom_atomic_number.argtypes = [Atom, POINTER(c_uint64)]
+    # Function "chfl_atom_atomic_number", at atom.h:201
+    c_lib.chfl_atom_atomic_number.argtypes = [POINTER(CHFL_ATOM), POINTER(c_uint64)]
     c_lib.chfl_atom_atomic_number.restype = chfl_status
     c_lib.chfl_atom_atomic_number.errcheck = _check_return_code
 
-    # Function "chfl_atom_properties_count", at atom.h:206
-    c_lib.chfl_atom_properties_count.argtypes = [Atom, POINTER(c_uint64)]
+    # Function "chfl_atom_properties_count", at atom.h:208
+    c_lib.chfl_atom_properties_count.argtypes = [POINTER(CHFL_ATOM), POINTER(c_uint64)]
     c_lib.chfl_atom_properties_count.restype = chfl_status
     c_lib.chfl_atom_properties_count.errcheck = _check_return_code
 
-    # Function "chfl_atom_list_properties", at atom.h:222
-    c_lib.chfl_atom_list_properties.argtypes = [Atom, POINTER(c_char_p), c_uint64]
+    # Function "chfl_atom_list_properties", at atom.h:224
+    c_lib.chfl_atom_list_properties.argtypes = [POINTER(CHFL_ATOM), POINTER(c_char_p), c_uint64]
     c_lib.chfl_atom_list_properties.restype = chfl_status
     c_lib.chfl_atom_list_properties.errcheck = _check_return_code
 
-    # Function "chfl_atom_set_property", at atom.h:234
-    c_lib.chfl_atom_set_property.argtypes = [Atom, c_char_p, Property]
+    # Function "chfl_atom_set_property", at atom.h:236
+    c_lib.chfl_atom_set_property.argtypes = [POINTER(CHFL_ATOM), c_char_p, POINTER(CHFL_PROPERTY)]
     c_lib.chfl_atom_set_property.restype = chfl_status
     c_lib.chfl_atom_set_property.errcheck = _check_return_code
 
-    # Function "chfl_atom_get_property", at atom.h:248
-    c_lib.chfl_atom_get_property.argtypes = [Atom, c_char_p]
+    # Function "chfl_atom_get_property", at atom.h:250
+    c_lib.chfl_atom_get_property.argtypes = [POINTER(CHFL_ATOM), c_char_p]
     c_lib.chfl_atom_get_property.restype = POINTER(CHFL_PROPERTY)
 
     # Function "chfl_residue", at residue.h:20
@@ -286,176 +276,176 @@ def set_interface(c_lib):
     c_lib.chfl_residue_with_id.argtypes = [c_char_p, c_uint64]
     c_lib.chfl_residue_with_id.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_from_topology", at residue.h:52
-    c_lib.chfl_residue_from_topology.argtypes = [Topology, c_uint64]
+    # Function "chfl_residue_from_topology", at residue.h:58
+    c_lib.chfl_residue_from_topology.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64]
     c_lib.chfl_residue_from_topology.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_for_atom", at residue.h:73
-    c_lib.chfl_residue_for_atom.argtypes = [Topology, c_uint64]
+    # Function "chfl_residue_for_atom", at residue.h:85
+    c_lib.chfl_residue_for_atom.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64]
     c_lib.chfl_residue_for_atom.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_copy", at residue.h:85
-    c_lib.chfl_residue_copy.argtypes = [Residue]
+    # Function "chfl_residue_copy", at residue.h:97
+    c_lib.chfl_residue_copy.argtypes = [POINTER(CHFL_RESIDUE)]
     c_lib.chfl_residue_copy.restype = POINTER(CHFL_RESIDUE)
 
-    # Function "chfl_residue_atoms_count", at residue.h:92
-    c_lib.chfl_residue_atoms_count.argtypes = [Residue, POINTER(c_uint64)]
+    # Function "chfl_residue_atoms_count", at residue.h:104
+    c_lib.chfl_residue_atoms_count.argtypes = [POINTER(CHFL_RESIDUE), POINTER(c_uint64)]
     c_lib.chfl_residue_atoms_count.restype = chfl_status
     c_lib.chfl_residue_atoms_count.errcheck = _check_return_code
 
-    # Function "chfl_residue_atoms", at residue.h:106
-    c_lib.chfl_residue_atoms.argtypes = [Residue, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=1), c_uint64]
+    # Function "chfl_residue_atoms", at residue.h:118
+    c_lib.chfl_residue_atoms.argtypes = [POINTER(CHFL_RESIDUE), ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=1), c_uint64]
     c_lib.chfl_residue_atoms.restype = chfl_status
     c_lib.chfl_residue_atoms.errcheck = _check_return_code
 
-    # Function "chfl_residue_id", at residue.h:119
-    c_lib.chfl_residue_id.argtypes = [Residue, POINTER(c_uint64)]
+    # Function "chfl_residue_id", at residue.h:131
+    c_lib.chfl_residue_id.argtypes = [POINTER(CHFL_RESIDUE), POINTER(c_uint64)]
     c_lib.chfl_residue_id.restype = chfl_status
     c_lib.chfl_residue_id.errcheck = _check_return_code
 
-    # Function "chfl_residue_name", at residue.h:131
-    c_lib.chfl_residue_name.argtypes = [Residue, c_char_p, c_uint64]
+    # Function "chfl_residue_name", at residue.h:143
+    c_lib.chfl_residue_name.argtypes = [POINTER(CHFL_RESIDUE), c_char_p, c_uint64]
     c_lib.chfl_residue_name.restype = chfl_status
     c_lib.chfl_residue_name.errcheck = _check_return_code
 
-    # Function "chfl_residue_add_atom", at residue.h:140
-    c_lib.chfl_residue_add_atom.argtypes = [Residue, c_uint64]
+    # Function "chfl_residue_add_atom", at residue.h:152
+    c_lib.chfl_residue_add_atom.argtypes = [POINTER(CHFL_RESIDUE), c_uint64]
     c_lib.chfl_residue_add_atom.restype = chfl_status
     c_lib.chfl_residue_add_atom.errcheck = _check_return_code
 
-    # Function "chfl_residue_contains", at residue.h:150
-    c_lib.chfl_residue_contains.argtypes = [Residue, c_uint64, POINTER(c_bool)]
+    # Function "chfl_residue_contains", at residue.h:162
+    c_lib.chfl_residue_contains.argtypes = [POINTER(CHFL_RESIDUE), c_uint64, POINTER(c_bool)]
     c_lib.chfl_residue_contains.restype = chfl_status
     c_lib.chfl_residue_contains.errcheck = _check_return_code
 
-    # Function "chfl_residue_properties_count", at residue.h:159
-    c_lib.chfl_residue_properties_count.argtypes = [Residue, POINTER(c_uint64)]
+    # Function "chfl_residue_properties_count", at residue.h:171
+    c_lib.chfl_residue_properties_count.argtypes = [POINTER(CHFL_RESIDUE), POINTER(c_uint64)]
     c_lib.chfl_residue_properties_count.restype = chfl_status
     c_lib.chfl_residue_properties_count.errcheck = _check_return_code
 
-    # Function "chfl_residue_list_properties", at residue.h:175
-    c_lib.chfl_residue_list_properties.argtypes = [Residue, POINTER(c_char_p), c_uint64]
+    # Function "chfl_residue_list_properties", at residue.h:187
+    c_lib.chfl_residue_list_properties.argtypes = [POINTER(CHFL_RESIDUE), POINTER(c_char_p), c_uint64]
     c_lib.chfl_residue_list_properties.restype = chfl_status
     c_lib.chfl_residue_list_properties.errcheck = _check_return_code
 
-    # Function "chfl_residue_set_property", at residue.h:187
-    c_lib.chfl_residue_set_property.argtypes = [Residue, c_char_p, Property]
+    # Function "chfl_residue_set_property", at residue.h:199
+    c_lib.chfl_residue_set_property.argtypes = [POINTER(CHFL_RESIDUE), c_char_p, POINTER(CHFL_PROPERTY)]
     c_lib.chfl_residue_set_property.restype = chfl_status
     c_lib.chfl_residue_set_property.errcheck = _check_return_code
 
-    # Function "chfl_residue_get_property", at residue.h:201
-    c_lib.chfl_residue_get_property.argtypes = [Residue, c_char_p]
+    # Function "chfl_residue_get_property", at residue.h:213
+    c_lib.chfl_residue_get_property.argtypes = [POINTER(CHFL_RESIDUE), c_char_p]
     c_lib.chfl_residue_get_property.restype = POINTER(CHFL_PROPERTY)
 
     # Function "chfl_topology", at topology.h:20
     c_lib.chfl_topology.argtypes = []
     c_lib.chfl_topology.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_from_frame", at topology.h:34
-    c_lib.chfl_topology_from_frame.argtypes = [Frame]
+    # Function "chfl_topology_from_frame", at topology.h:33
+    c_lib.chfl_topology_from_frame.argtypes = [POINTER(CHFL_FRAME)]
     c_lib.chfl_topology_from_frame.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_copy", at topology.h:44
-    c_lib.chfl_topology_copy.argtypes = [Topology]
+    # Function "chfl_topology_copy", at topology.h:43
+    c_lib.chfl_topology_copy.argtypes = [POINTER(CHFL_TOPOLOGY)]
     c_lib.chfl_topology_copy.restype = POINTER(CHFL_TOPOLOGY)
 
-    # Function "chfl_topology_atoms_count", at topology.h:52
-    c_lib.chfl_topology_atoms_count.argtypes = [Topology, POINTER(c_uint64)]
+    # Function "chfl_topology_atoms_count", at topology.h:51
+    c_lib.chfl_topology_atoms_count.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(c_uint64)]
     c_lib.chfl_topology_atoms_count.restype = chfl_status
     c_lib.chfl_topology_atoms_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_resize", at topology.h:64
-    c_lib.chfl_topology_resize.argtypes = [Topology, c_uint64]
+    # Function "chfl_topology_resize", at topology.h:63
+    c_lib.chfl_topology_resize.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64]
     c_lib.chfl_topology_resize.restype = chfl_status
     c_lib.chfl_topology_resize.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_atom", at topology.h:71
-    c_lib.chfl_topology_add_atom.argtypes = [Topology, Atom]
+    # Function "chfl_topology_add_atom", at topology.h:70
+    c_lib.chfl_topology_add_atom.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(CHFL_ATOM)]
     c_lib.chfl_topology_add_atom.restype = chfl_status
     c_lib.chfl_topology_add_atom.errcheck = _check_return_code
 
-    # Function "chfl_topology_remove", at topology.h:82
-    c_lib.chfl_topology_remove.argtypes = [Topology, c_uint64]
+    # Function "chfl_topology_remove", at topology.h:81
+    c_lib.chfl_topology_remove.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64]
     c_lib.chfl_topology_remove.restype = chfl_status
     c_lib.chfl_topology_remove.errcheck = _check_return_code
 
-    # Function "chfl_topology_bonds_count", at topology.h:91
-    c_lib.chfl_topology_bonds_count.argtypes = [Topology, POINTER(c_uint64)]
+    # Function "chfl_topology_bonds_count", at topology.h:90
+    c_lib.chfl_topology_bonds_count.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(c_uint64)]
     c_lib.chfl_topology_bonds_count.restype = chfl_status
     c_lib.chfl_topology_bonds_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_angles_count", at topology.h:100
-    c_lib.chfl_topology_angles_count.argtypes = [Topology, POINTER(c_uint64)]
+    # Function "chfl_topology_angles_count", at topology.h:99
+    c_lib.chfl_topology_angles_count.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(c_uint64)]
     c_lib.chfl_topology_angles_count.restype = chfl_status
     c_lib.chfl_topology_angles_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_dihedrals_count", at topology.h:109
-    c_lib.chfl_topology_dihedrals_count.argtypes = [Topology, POINTER(c_uint64)]
+    # Function "chfl_topology_dihedrals_count", at topology.h:108
+    c_lib.chfl_topology_dihedrals_count.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(c_uint64)]
     c_lib.chfl_topology_dihedrals_count.restype = chfl_status
     c_lib.chfl_topology_dihedrals_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_impropers_count", at topology.h:118
-    c_lib.chfl_topology_impropers_count.argtypes = [Topology, POINTER(c_uint64)]
+    # Function "chfl_topology_impropers_count", at topology.h:117
+    c_lib.chfl_topology_impropers_count.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(c_uint64)]
     c_lib.chfl_topology_impropers_count.restype = chfl_status
     c_lib.chfl_topology_impropers_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_bonds", at topology.h:131
-    c_lib.chfl_topology_bonds.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    # Function "chfl_topology_bonds", at topology.h:130
+    c_lib.chfl_topology_bonds.argtypes = [POINTER(CHFL_TOPOLOGY), ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_bonds.restype = chfl_status
     c_lib.chfl_topology_bonds.errcheck = _check_return_code
 
-    # Function "chfl_topology_angles", at topology.h:144
-    c_lib.chfl_topology_angles.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    # Function "chfl_topology_angles", at topology.h:143
+    c_lib.chfl_topology_angles.argtypes = [POINTER(CHFL_TOPOLOGY), ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_angles.restype = chfl_status
     c_lib.chfl_topology_angles.errcheck = _check_return_code
 
-    # Function "chfl_topology_dihedrals", at topology.h:158
-    c_lib.chfl_topology_dihedrals.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    # Function "chfl_topology_dihedrals", at topology.h:157
+    c_lib.chfl_topology_dihedrals.argtypes = [POINTER(CHFL_TOPOLOGY), ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_dihedrals.restype = chfl_status
     c_lib.chfl_topology_dihedrals.errcheck = _check_return_code
 
-    # Function "chfl_topology_impropers", at topology.h:172
-    c_lib.chfl_topology_impropers.argtypes = [Topology, ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
+    # Function "chfl_topology_impropers", at topology.h:171
+    c_lib.chfl_topology_impropers.argtypes = [POINTER(CHFL_TOPOLOGY), ndpointer(np.uint64, flags="C_CONTIGUOUS", ndim=2), c_uint64]
     c_lib.chfl_topology_impropers.restype = chfl_status
     c_lib.chfl_topology_impropers.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_bond", at topology.h:181
-    c_lib.chfl_topology_add_bond.argtypes = [Topology, c_uint64, c_uint64]
+    # Function "chfl_topology_add_bond", at topology.h:180
+    c_lib.chfl_topology_add_bond.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64, c_uint64]
     c_lib.chfl_topology_add_bond.restype = chfl_status
     c_lib.chfl_topology_add_bond.errcheck = _check_return_code
 
-    # Function "chfl_topology_remove_bond", at topology.h:193
-    c_lib.chfl_topology_remove_bond.argtypes = [Topology, c_uint64, c_uint64]
+    # Function "chfl_topology_remove_bond", at topology.h:192
+    c_lib.chfl_topology_remove_bond.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64, c_uint64]
     c_lib.chfl_topology_remove_bond.restype = chfl_status
     c_lib.chfl_topology_remove_bond.errcheck = _check_return_code
 
-    # Function "chfl_topology_residues_count", at topology.h:203
-    c_lib.chfl_topology_residues_count.argtypes = [Topology, POINTER(c_uint64)]
+    # Function "chfl_topology_residues_count", at topology.h:202
+    c_lib.chfl_topology_residues_count.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(c_uint64)]
     c_lib.chfl_topology_residues_count.restype = chfl_status
     c_lib.chfl_topology_residues_count.errcheck = _check_return_code
 
-    # Function "chfl_topology_add_residue", at topology.h:215
-    c_lib.chfl_topology_add_residue.argtypes = [Topology, Residue]
+    # Function "chfl_topology_add_residue", at topology.h:214
+    c_lib.chfl_topology_add_residue.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(CHFL_RESIDUE)]
     c_lib.chfl_topology_add_residue.restype = chfl_status
     c_lib.chfl_topology_add_residue.errcheck = _check_return_code
 
-    # Function "chfl_topology_residues_linked", at topology.h:226
-    c_lib.chfl_topology_residues_linked.argtypes = [Topology, Residue, Residue, POINTER(c_bool)]
+    # Function "chfl_topology_residues_linked", at topology.h:225
+    c_lib.chfl_topology_residues_linked.argtypes = [POINTER(CHFL_TOPOLOGY), POINTER(CHFL_RESIDUE), POINTER(CHFL_RESIDUE), POINTER(c_bool)]
     c_lib.chfl_topology_residues_linked.restype = chfl_status
     c_lib.chfl_topology_residues_linked.errcheck = _check_return_code
 
-    # Function "chfl_topology_bond_with_order", at topology.h:239
-    c_lib.chfl_topology_bond_with_order.argtypes = [Topology, c_uint64, c_uint64, chfl_bond_order]
+    # Function "chfl_topology_bond_with_order", at topology.h:238
+    c_lib.chfl_topology_bond_with_order.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64, c_uint64, chfl_bond_order]
     c_lib.chfl_topology_bond_with_order.restype = chfl_status
     c_lib.chfl_topology_bond_with_order.errcheck = _check_return_code
 
-    # Function "chfl_topology_bond_orders", at topology.h:253
-    c_lib.chfl_topology_bond_orders.argtypes = [Topology, ndpointer(chfl_bond_order, flags="C_CONTIGUOUS", ndim=1), c_uint64]
+    # Function "chfl_topology_bond_orders", at topology.h:252
+    c_lib.chfl_topology_bond_orders.argtypes = [POINTER(CHFL_TOPOLOGY), ndpointer(chfl_bond_order, flags="C_CONTIGUOUS", ndim=1), c_uint64]
     c_lib.chfl_topology_bond_orders.restype = chfl_status
     c_lib.chfl_topology_bond_orders.errcheck = _check_return_code
 
-    # Function "chfl_topology_bond_order", at topology.h:266
-    c_lib.chfl_topology_bond_order.argtypes = [Topology, c_uint64, c_uint64, POINTER(chfl_bond_order)]
+    # Function "chfl_topology_bond_order", at topology.h:265
+    c_lib.chfl_topology_bond_order.argtypes = [POINTER(CHFL_TOPOLOGY), c_uint64, c_uint64, POINTER(chfl_bond_order)]
     c_lib.chfl_topology_bond_order.restype = chfl_status
     c_lib.chfl_topology_bond_order.errcheck = _check_return_code
 
@@ -467,56 +457,56 @@ def set_interface(c_lib):
     c_lib.chfl_cell_triclinic.argtypes = [chfl_vector3d, chfl_vector3d]
     c_lib.chfl_cell_triclinic.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_from_frame", at cell.h:72
-    c_lib.chfl_cell_from_frame.argtypes = [Frame]
+    # Function "chfl_cell_from_frame", at cell.h:65
+    c_lib.chfl_cell_from_frame.argtypes = [POINTER(CHFL_FRAME)]
     c_lib.chfl_cell_from_frame.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_copy", at cell.h:82
-    c_lib.chfl_cell_copy.argtypes = [UnitCell]
+    # Function "chfl_cell_copy", at cell.h:75
+    c_lib.chfl_cell_copy.argtypes = [POINTER(CHFL_CELL)]
     c_lib.chfl_cell_copy.restype = POINTER(CHFL_CELL)
 
-    # Function "chfl_cell_volume", at cell.h:89
-    c_lib.chfl_cell_volume.argtypes = [UnitCell, POINTER(c_double)]
+    # Function "chfl_cell_volume", at cell.h:82
+    c_lib.chfl_cell_volume.argtypes = [POINTER(CHFL_CELL), POINTER(c_double)]
     c_lib.chfl_cell_volume.restype = chfl_status
     c_lib.chfl_cell_volume.errcheck = _check_return_code
 
-    # Function "chfl_cell_lengths", at cell.h:98
-    c_lib.chfl_cell_lengths.argtypes = [UnitCell, chfl_vector3d]
+    # Function "chfl_cell_lengths", at cell.h:91
+    c_lib.chfl_cell_lengths.argtypes = [POINTER(CHFL_CELL), chfl_vector3d]
     c_lib.chfl_cell_lengths.restype = chfl_status
     c_lib.chfl_cell_lengths.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_lengths", at cell.h:109
-    c_lib.chfl_cell_set_lengths.argtypes = [UnitCell, chfl_vector3d]
+    # Function "chfl_cell_set_lengths", at cell.h:102
+    c_lib.chfl_cell_set_lengths.argtypes = [POINTER(CHFL_CELL), chfl_vector3d]
     c_lib.chfl_cell_set_lengths.restype = chfl_status
     c_lib.chfl_cell_set_lengths.errcheck = _check_return_code
 
-    # Function "chfl_cell_angles", at cell.h:118
-    c_lib.chfl_cell_angles.argtypes = [UnitCell, chfl_vector3d]
+    # Function "chfl_cell_angles", at cell.h:111
+    c_lib.chfl_cell_angles.argtypes = [POINTER(CHFL_CELL), chfl_vector3d]
     c_lib.chfl_cell_angles.restype = chfl_status
     c_lib.chfl_cell_angles.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_angles", at cell.h:131
-    c_lib.chfl_cell_set_angles.argtypes = [UnitCell, chfl_vector3d]
+    # Function "chfl_cell_set_angles", at cell.h:124
+    c_lib.chfl_cell_set_angles.argtypes = [POINTER(CHFL_CELL), chfl_vector3d]
     c_lib.chfl_cell_set_angles.restype = chfl_status
     c_lib.chfl_cell_set_angles.errcheck = _check_return_code
 
-    # Function "chfl_cell_matrix", at cell.h:149
-    c_lib.chfl_cell_matrix.argtypes = [UnitCell, ARRAY(chfl_vector3d, (3))]
+    # Function "chfl_cell_matrix", at cell.h:142
+    c_lib.chfl_cell_matrix.argtypes = [POINTER(CHFL_CELL), ARRAY(chfl_vector3d, (3))]
     c_lib.chfl_cell_matrix.restype = chfl_status
     c_lib.chfl_cell_matrix.errcheck = _check_return_code
 
-    # Function "chfl_cell_shape", at cell.h:158
-    c_lib.chfl_cell_shape.argtypes = [UnitCell, POINTER(chfl_cellshape)]
+    # Function "chfl_cell_shape", at cell.h:151
+    c_lib.chfl_cell_shape.argtypes = [POINTER(CHFL_CELL), POINTER(chfl_cellshape)]
     c_lib.chfl_cell_shape.restype = chfl_status
     c_lib.chfl_cell_shape.errcheck = _check_return_code
 
-    # Function "chfl_cell_set_shape", at cell.h:167
-    c_lib.chfl_cell_set_shape.argtypes = [UnitCell, chfl_cellshape]
+    # Function "chfl_cell_set_shape", at cell.h:160
+    c_lib.chfl_cell_set_shape.argtypes = [POINTER(CHFL_CELL), chfl_cellshape]
     c_lib.chfl_cell_set_shape.restype = chfl_status
     c_lib.chfl_cell_set_shape.errcheck = _check_return_code
 
-    # Function "chfl_cell_wrap", at cell.h:176
-    c_lib.chfl_cell_wrap.argtypes = [UnitCell, chfl_vector3d]
+    # Function "chfl_cell_wrap", at cell.h:169
+    c_lib.chfl_cell_wrap.argtypes = [POINTER(CHFL_CELL), chfl_vector3d]
     c_lib.chfl_cell_wrap.restype = chfl_status
     c_lib.chfl_cell_wrap.errcheck = _check_return_code
 
@@ -525,130 +515,130 @@ def set_interface(c_lib):
     c_lib.chfl_frame.restype = POINTER(CHFL_FRAME)
 
     # Function "chfl_frame_copy", at frame.h:30
-    c_lib.chfl_frame_copy.argtypes = [Frame]
+    c_lib.chfl_frame_copy.argtypes = [POINTER(CHFL_FRAME)]
     c_lib.chfl_frame_copy.restype = POINTER(CHFL_FRAME)
 
     # Function "chfl_frame_atoms_count", at frame.h:38
-    c_lib.chfl_frame_atoms_count.argtypes = [Frame, POINTER(c_uint64)]
+    c_lib.chfl_frame_atoms_count.argtypes = [POINTER(CHFL_FRAME), POINTER(c_uint64)]
     c_lib.chfl_frame_atoms_count.restype = chfl_status
     c_lib.chfl_frame_atoms_count.errcheck = _check_return_code
 
     # Function "chfl_frame_positions", at frame.h:57
-    c_lib.chfl_frame_positions.argtypes = [Frame, POINTER(POINTER(chfl_vector3d)), POINTER(c_uint64)]
+    c_lib.chfl_frame_positions.argtypes = [POINTER(CHFL_FRAME), POINTER(POINTER(chfl_vector3d)), POINTER(c_uint64)]
     c_lib.chfl_frame_positions.restype = chfl_status
     c_lib.chfl_frame_positions.errcheck = _check_return_code
 
     # Function "chfl_frame_velocities", at frame.h:80
-    c_lib.chfl_frame_velocities.argtypes = [Frame, POINTER(POINTER(chfl_vector3d)), POINTER(c_uint64)]
+    c_lib.chfl_frame_velocities.argtypes = [POINTER(CHFL_FRAME), POINTER(POINTER(chfl_vector3d)), POINTER(c_uint64)]
     c_lib.chfl_frame_velocities.restype = chfl_status
     c_lib.chfl_frame_velocities.errcheck = _check_return_code
 
     # Function "chfl_frame_add_atom", at frame.h:92
-    c_lib.chfl_frame_add_atom.argtypes = [Frame, Atom, chfl_vector3d, chfl_vector3d]
+    c_lib.chfl_frame_add_atom.argtypes = [POINTER(CHFL_FRAME), POINTER(CHFL_ATOM), chfl_vector3d, chfl_vector3d]
     c_lib.chfl_frame_add_atom.restype = chfl_status
     c_lib.chfl_frame_add_atom.errcheck = _check_return_code
 
     # Function "chfl_frame_remove", at frame.h:105
-    c_lib.chfl_frame_remove.argtypes = [Frame, c_uint64]
+    c_lib.chfl_frame_remove.argtypes = [POINTER(CHFL_FRAME), c_uint64]
     c_lib.chfl_frame_remove.restype = chfl_status
     c_lib.chfl_frame_remove.errcheck = _check_return_code
 
     # Function "chfl_frame_resize", at frame.h:117
-    c_lib.chfl_frame_resize.argtypes = [Frame, c_uint64]
+    c_lib.chfl_frame_resize.argtypes = [POINTER(CHFL_FRAME), c_uint64]
     c_lib.chfl_frame_resize.restype = chfl_status
     c_lib.chfl_frame_resize.errcheck = _check_return_code
 
     # Function "chfl_frame_add_velocities", at frame.h:129
-    c_lib.chfl_frame_add_velocities.argtypes = [Frame]
+    c_lib.chfl_frame_add_velocities.argtypes = [POINTER(CHFL_FRAME)]
     c_lib.chfl_frame_add_velocities.restype = chfl_status
     c_lib.chfl_frame_add_velocities.errcheck = _check_return_code
 
     # Function "chfl_frame_has_velocities", at frame.h:137
-    c_lib.chfl_frame_has_velocities.argtypes = [Frame, POINTER(c_bool)]
+    c_lib.chfl_frame_has_velocities.argtypes = [POINTER(CHFL_FRAME), POINTER(c_bool)]
     c_lib.chfl_frame_has_velocities.restype = chfl_status
     c_lib.chfl_frame_has_velocities.errcheck = _check_return_code
 
     # Function "chfl_frame_set_cell", at frame.h:146
-    c_lib.chfl_frame_set_cell.argtypes = [Frame, UnitCell]
+    c_lib.chfl_frame_set_cell.argtypes = [POINTER(CHFL_FRAME), POINTER(CHFL_CELL)]
     c_lib.chfl_frame_set_cell.restype = chfl_status
     c_lib.chfl_frame_set_cell.errcheck = _check_return_code
 
     # Function "chfl_frame_set_topology", at frame.h:158
-    c_lib.chfl_frame_set_topology.argtypes = [Frame, Topology]
+    c_lib.chfl_frame_set_topology.argtypes = [POINTER(CHFL_FRAME), POINTER(CHFL_TOPOLOGY)]
     c_lib.chfl_frame_set_topology.restype = chfl_status
     c_lib.chfl_frame_set_topology.errcheck = _check_return_code
 
     # Function "chfl_frame_step", at frame.h:168
-    c_lib.chfl_frame_step.argtypes = [Frame, POINTER(c_uint64)]
+    c_lib.chfl_frame_step.argtypes = [POINTER(CHFL_FRAME), POINTER(c_uint64)]
     c_lib.chfl_frame_step.restype = chfl_status
     c_lib.chfl_frame_step.errcheck = _check_return_code
 
     # Function "chfl_frame_set_step", at frame.h:177
-    c_lib.chfl_frame_set_step.argtypes = [Frame, c_uint64]
+    c_lib.chfl_frame_set_step.argtypes = [POINTER(CHFL_FRAME), c_uint64]
     c_lib.chfl_frame_set_step.restype = chfl_status
     c_lib.chfl_frame_set_step.errcheck = _check_return_code
 
     # Function "chfl_frame_guess_bonds", at frame.h:189
-    c_lib.chfl_frame_guess_bonds.argtypes = [Frame]
+    c_lib.chfl_frame_guess_bonds.argtypes = [POINTER(CHFL_FRAME)]
     c_lib.chfl_frame_guess_bonds.restype = chfl_status
     c_lib.chfl_frame_guess_bonds.errcheck = _check_return_code
 
     # Function "chfl_frame_distance", at frame.h:198
-    c_lib.chfl_frame_distance.argtypes = [Frame, c_uint64, c_uint64, POINTER(c_double)]
+    c_lib.chfl_frame_distance.argtypes = [POINTER(CHFL_FRAME), c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_distance.restype = chfl_status
     c_lib.chfl_frame_distance.errcheck = _check_return_code
 
     # Function "chfl_frame_angle", at frame.h:209
-    c_lib.chfl_frame_angle.argtypes = [Frame, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
+    c_lib.chfl_frame_angle.argtypes = [POINTER(CHFL_FRAME), c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_angle.restype = chfl_status
     c_lib.chfl_frame_angle.errcheck = _check_return_code
 
     # Function "chfl_frame_dihedral", at frame.h:220
-    c_lib.chfl_frame_dihedral.argtypes = [Frame, c_uint64, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
+    c_lib.chfl_frame_dihedral.argtypes = [POINTER(CHFL_FRAME), c_uint64, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_dihedral.restype = chfl_status
     c_lib.chfl_frame_dihedral.errcheck = _check_return_code
 
     # Function "chfl_frame_out_of_plane", at frame.h:234
-    c_lib.chfl_frame_out_of_plane.argtypes = [Frame, c_uint64, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
+    c_lib.chfl_frame_out_of_plane.argtypes = [POINTER(CHFL_FRAME), c_uint64, c_uint64, c_uint64, c_uint64, POINTER(c_double)]
     c_lib.chfl_frame_out_of_plane.restype = chfl_status
     c_lib.chfl_frame_out_of_plane.errcheck = _check_return_code
 
     # Function "chfl_frame_properties_count", at frame.h:243
-    c_lib.chfl_frame_properties_count.argtypes = [Frame, POINTER(c_uint64)]
+    c_lib.chfl_frame_properties_count.argtypes = [POINTER(CHFL_FRAME), POINTER(c_uint64)]
     c_lib.chfl_frame_properties_count.restype = chfl_status
     c_lib.chfl_frame_properties_count.errcheck = _check_return_code
 
     # Function "chfl_frame_list_properties", at frame.h:259
-    c_lib.chfl_frame_list_properties.argtypes = [Frame, POINTER(c_char_p), c_uint64]
+    c_lib.chfl_frame_list_properties.argtypes = [POINTER(CHFL_FRAME), POINTER(c_char_p), c_uint64]
     c_lib.chfl_frame_list_properties.restype = chfl_status
     c_lib.chfl_frame_list_properties.errcheck = _check_return_code
 
     # Function "chfl_frame_set_property", at frame.h:271
-    c_lib.chfl_frame_set_property.argtypes = [Frame, c_char_p, Property]
+    c_lib.chfl_frame_set_property.argtypes = [POINTER(CHFL_FRAME), c_char_p, POINTER(CHFL_PROPERTY)]
     c_lib.chfl_frame_set_property.restype = chfl_status
     c_lib.chfl_frame_set_property.errcheck = _check_return_code
 
     # Function "chfl_frame_get_property", at frame.h:285
-    c_lib.chfl_frame_get_property.argtypes = [Frame, c_char_p]
+    c_lib.chfl_frame_get_property.argtypes = [POINTER(CHFL_FRAME), c_char_p]
     c_lib.chfl_frame_get_property.restype = POINTER(CHFL_PROPERTY)
 
     # Function "chfl_frame_add_bond", at frame.h:294
-    c_lib.chfl_frame_add_bond.argtypes = [Frame, c_uint64, c_uint64]
+    c_lib.chfl_frame_add_bond.argtypes = [POINTER(CHFL_FRAME), c_uint64, c_uint64]
     c_lib.chfl_frame_add_bond.restype = chfl_status
     c_lib.chfl_frame_add_bond.errcheck = _check_return_code
 
     # Function "chfl_frame_bond_with_order", at frame.h:304
-    c_lib.chfl_frame_bond_with_order.argtypes = [Frame, c_uint64, c_uint64, chfl_bond_order]
+    c_lib.chfl_frame_bond_with_order.argtypes = [POINTER(CHFL_FRAME), c_uint64, c_uint64, chfl_bond_order]
     c_lib.chfl_frame_bond_with_order.restype = chfl_status
     c_lib.chfl_frame_bond_with_order.errcheck = _check_return_code
 
     # Function "chfl_frame_remove_bond", at frame.h:316
-    c_lib.chfl_frame_remove_bond.argtypes = [Frame, c_uint64, c_uint64]
+    c_lib.chfl_frame_remove_bond.argtypes = [POINTER(CHFL_FRAME), c_uint64, c_uint64]
     c_lib.chfl_frame_remove_bond.restype = chfl_status
     c_lib.chfl_frame_remove_bond.errcheck = _check_return_code
 
     # Function "chfl_frame_add_residue", at frame.h:328
-    c_lib.chfl_frame_add_residue.argtypes = [Frame, Residue]
+    c_lib.chfl_frame_add_residue.argtypes = [POINTER(CHFL_FRAME), POINTER(CHFL_RESIDUE)]
     c_lib.chfl_frame_add_residue.restype = chfl_status
     c_lib.chfl_frame_add_residue.errcheck = _check_return_code
 
@@ -661,42 +651,42 @@ def set_interface(c_lib):
     c_lib.chfl_trajectory_with_format.restype = POINTER(CHFL_TRAJECTORY)
 
     # Function "chfl_trajectory_path", at trajectory.h:52
-    c_lib.chfl_trajectory_path.argtypes = [Trajectory, POINTER(c_char_p)]
+    c_lib.chfl_trajectory_path.argtypes = [POINTER(CHFL_TRAJECTORY), POINTER(c_char_p)]
     c_lib.chfl_trajectory_path.restype = chfl_status
     c_lib.chfl_trajectory_path.errcheck = _check_return_code
 
     # Function "chfl_trajectory_read", at trajectory.h:64
-    c_lib.chfl_trajectory_read.argtypes = [Trajectory, Frame]
+    c_lib.chfl_trajectory_read.argtypes = [POINTER(CHFL_TRAJECTORY), POINTER(CHFL_FRAME)]
     c_lib.chfl_trajectory_read.restype = chfl_status
     c_lib.chfl_trajectory_read.errcheck = _check_return_code
 
     # Function "chfl_trajectory_read_step", at trajectory.h:76
-    c_lib.chfl_trajectory_read_step.argtypes = [Trajectory, c_uint64, Frame]
+    c_lib.chfl_trajectory_read_step.argtypes = [POINTER(CHFL_TRAJECTORY), c_uint64, POINTER(CHFL_FRAME)]
     c_lib.chfl_trajectory_read_step.restype = chfl_status
     c_lib.chfl_trajectory_read_step.errcheck = _check_return_code
 
     # Function "chfl_trajectory_write", at trajectory.h:85
-    c_lib.chfl_trajectory_write.argtypes = [Trajectory, Frame]
+    c_lib.chfl_trajectory_write.argtypes = [POINTER(CHFL_TRAJECTORY), POINTER(CHFL_FRAME)]
     c_lib.chfl_trajectory_write.restype = chfl_status
     c_lib.chfl_trajectory_write.errcheck = _check_return_code
 
     # Function "chfl_trajectory_set_topology", at trajectory.h:96
-    c_lib.chfl_trajectory_set_topology.argtypes = [Trajectory, Topology]
+    c_lib.chfl_trajectory_set_topology.argtypes = [POINTER(CHFL_TRAJECTORY), POINTER(CHFL_TOPOLOGY)]
     c_lib.chfl_trajectory_set_topology.restype = chfl_status
     c_lib.chfl_trajectory_set_topology.errcheck = _check_return_code
 
     # Function "chfl_trajectory_topology_file", at trajectory.h:110
-    c_lib.chfl_trajectory_topology_file.argtypes = [Trajectory, c_char_p, c_char_p]
+    c_lib.chfl_trajectory_topology_file.argtypes = [POINTER(CHFL_TRAJECTORY), c_char_p, c_char_p]
     c_lib.chfl_trajectory_topology_file.restype = chfl_status
     c_lib.chfl_trajectory_topology_file.errcheck = _check_return_code
 
     # Function "chfl_trajectory_set_cell", at trajectory.h:120
-    c_lib.chfl_trajectory_set_cell.argtypes = [Trajectory, UnitCell]
+    c_lib.chfl_trajectory_set_cell.argtypes = [POINTER(CHFL_TRAJECTORY), POINTER(CHFL_CELL)]
     c_lib.chfl_trajectory_set_cell.restype = chfl_status
     c_lib.chfl_trajectory_set_cell.errcheck = _check_return_code
 
     # Function "chfl_trajectory_nsteps", at trajectory.h:130
-    c_lib.chfl_trajectory_nsteps.argtypes = [Trajectory, POINTER(c_uint64)]
+    c_lib.chfl_trajectory_nsteps.argtypes = [POINTER(CHFL_TRAJECTORY), POINTER(c_uint64)]
     c_lib.chfl_trajectory_nsteps.restype = chfl_status
     c_lib.chfl_trajectory_nsteps.errcheck = _check_return_code
 
@@ -705,25 +695,25 @@ def set_interface(c_lib):
     c_lib.chfl_selection.restype = POINTER(CHFL_SELECTION)
 
     # Function "chfl_selection_copy", at selection.h:33
-    c_lib.chfl_selection_copy.argtypes = [Selection]
+    c_lib.chfl_selection_copy.argtypes = [POINTER(CHFL_SELECTION)]
     c_lib.chfl_selection_copy.restype = POINTER(CHFL_SELECTION)
 
     # Function "chfl_selection_size", at selection.h:45
-    c_lib.chfl_selection_size.argtypes = [Selection, POINTER(c_uint64)]
+    c_lib.chfl_selection_size.argtypes = [POINTER(CHFL_SELECTION), POINTER(c_uint64)]
     c_lib.chfl_selection_size.restype = chfl_status
     c_lib.chfl_selection_size.errcheck = _check_return_code
 
     # Function "chfl_selection_string", at selection.h:58
-    c_lib.chfl_selection_string.argtypes = [Selection, c_char_p, c_uint64]
+    c_lib.chfl_selection_string.argtypes = [POINTER(CHFL_SELECTION), c_char_p, c_uint64]
     c_lib.chfl_selection_string.restype = chfl_status
     c_lib.chfl_selection_string.errcheck = _check_return_code
 
     # Function "chfl_selection_evaluate", at selection.h:71
-    c_lib.chfl_selection_evaluate.argtypes = [Selection, Frame, POINTER(c_uint64)]
+    c_lib.chfl_selection_evaluate.argtypes = [POINTER(CHFL_SELECTION), POINTER(CHFL_FRAME), POINTER(c_uint64)]
     c_lib.chfl_selection_evaluate.restype = chfl_status
     c_lib.chfl_selection_evaluate.errcheck = _check_return_code
 
     # Function "chfl_selection_matches", at selection.h:97
-    c_lib.chfl_selection_matches.argtypes = [Selection, ndpointer(chfl_match, flags="C_CONTIGUOUS", ndim=1), c_uint64]
+    c_lib.chfl_selection_matches.argtypes = [POINTER(CHFL_SELECTION), ndpointer(chfl_match, flags="C_CONTIGUOUS", ndim=1), c_uint64]
     c_lib.chfl_selection_matches.restype = chfl_status
     c_lib.chfl_selection_matches.errcheck = _check_return_code

--- a/chemfiles/property.py
+++ b/chemfiles/property.py
@@ -6,7 +6,7 @@ from ctypes import c_double, c_bool
 
 from .ffi import chfl_property_kind, chfl_vector3d
 from .misc import ChemfilesError
-from ._utils import CxxPointer, _call_with_growing_buffer, string_type
+from .utils import CxxPointer, _call_with_growing_buffer, string_type
 
 
 class Property(CxxPointer):
@@ -38,24 +38,24 @@ class Property(CxxPointer):
 
     def get(self):
         kind = chfl_property_kind()
-        self.ffi.chfl_property_get_kind(self, kind)
+        self.ffi.chfl_property_get_kind(self.ptr, kind)
         if kind.value == chfl_property_kind.CHFL_PROPERTY_BOOL:
             value = c_bool()
-            self.ffi.chfl_property_get_bool(self, value)
+            self.ffi.chfl_property_get_bool(self.ptr, value)
             return value.value
         if kind.value == chfl_property_kind.CHFL_PROPERTY_DOUBLE:
             value = c_double()
-            self.ffi.chfl_property_get_double(self, value)
+            self.ffi.chfl_property_get_double(self.ptr, value)
             return value.value
         if kind.value == chfl_property_kind.CHFL_PROPERTY_STRING:
 
             def callback(buffer, size):
-                self.ffi.chfl_property_get_string(self, buffer, size)
+                self.ffi.chfl_property_get_string(self.ptr, buffer, size)
 
             return _call_with_growing_buffer(callback, initial=32)
         if kind.value == chfl_property_kind.CHFL_PROPERTY_VECTOR3D:
             value = chfl_vector3d()
-            self.ffi.chfl_property_get_vector3d(self, value)
+            self.ffi.chfl_property_get_vector3d(self.ptr, value)
             return value[0], value[1], value[2]
         else:
             raise ChemfilesError("unknown property kind, this is a bug")
@@ -65,5 +65,5 @@ def _is_vector3d(value):
     try:
         a = np.array(value, dtype="double")
         return len(a) >= 3
-    except:
+    except Exception:
         return False

--- a/chemfiles/trajectory.py
+++ b/chemfiles/trajectory.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import ctypes
 from ctypes import c_uint64, c_char_p
 
-from ._utils import CxxPointer
+from .utils import CxxPointer
 from .frame import Frame, Topology
 from .misc import ChemfilesError
 
@@ -66,7 +66,7 @@ class Trajectory(CxxPointer):
         """
         self.__check_opened()
         frame = Frame()
-        self.ffi.chfl_trajectory_read(self, frame)
+        self.ffi.chfl_trajectory_read(self.mut_ptr, frame.mut_ptr)
         return frame
 
     def read_step(self, step):
@@ -76,13 +76,13 @@ class Trajectory(CxxPointer):
         """
         self.__check_opened()
         frame = Frame()
-        self.ffi.chfl_trajectory_read_step(self, c_uint64(step), frame)
+        self.ffi.chfl_trajectory_read_step(self.mut_ptr, c_uint64(step), frame.mut_ptr)
         return frame
 
     def write(self, frame):
         """Write a :py:class:`Frame` to the :py:class:`Trajectory`."""
         self.__check_opened()
-        self.ffi.chfl_trajectory_write(self, frame)
+        self.ffi.chfl_trajectory_write(self.mut_ptr, frame.ptr)
 
     def set_topology(self, topology, format=""):
         """
@@ -100,10 +100,10 @@ class Trajectory(CxxPointer):
         """
         self.__check_opened()
         if isinstance(topology, Topology):
-            self.ffi.chfl_trajectory_set_topology(self, topology)
+            self.ffi.chfl_trajectory_set_topology(self.mut_ptr, topology.ptr)
         else:
             self.ffi.chfl_trajectory_topology_file(
-                self, topology.encode("utf8"), format.encode("utf8")
+                self.mut_ptr, topology.encode("utf8"), format.encode("utf8")
             )
 
     def set_cell(self, cell):
@@ -113,7 +113,7 @@ class Trajectory(CxxPointer):
         files, replacing any :py:class:`UnitCell` in the frames or files.
         """
         self.__check_opened()
-        self.ffi.chfl_trajectory_set_cell(self, cell)
+        self.ffi.chfl_trajectory_set_cell(self.mut_ptr, cell.ptr)
 
     @property
     def nsteps(self):
@@ -123,7 +123,7 @@ class Trajectory(CxxPointer):
         """
         self.__check_opened()
         nsteps = c_uint64()
-        self.ffi.chfl_trajectory_nsteps(self, nsteps)
+        self.ffi.chfl_trajectory_nsteps(self.mut_ptr, nsteps)
         return nsteps.value
 
     @property
@@ -131,7 +131,7 @@ class Trajectory(CxxPointer):
         """Get the path used to open this  :py:class:`Trajectory`."""
         self.__check_opened()
         path = c_char_p()
-        self.ffi.chfl_trajectory_path(self, path)
+        self.ffi.chfl_trajectory_path(self.ptr, path)
         return path.value.decode('utf-8')
 
     def close(self):
@@ -141,4 +141,4 @@ class Trajectory(CxxPointer):
         """
         self.__check_opened()
         self.__closed = True
-        self.ffi.chfl_trajectory_close(self)
+        self.ffi.chfl_trajectory_close(self.ptr)

--- a/chemfiles/utils.py
+++ b/chemfiles/utils.py
@@ -25,7 +25,7 @@ class CxxPointer(object):
 
     def __del__(self):
         """Free the memory associated with this instance"""
-        self.ffi.chfl_free(self)
+        self.ffi.chfl_free(self.ptr)
 
     def __setattr__(self, key, value):
         if self.__frozen and not hasattr(self, key):
@@ -35,7 +35,7 @@ class CxxPointer(object):
         object.__setattr__(self, key, value)
 
     @classmethod
-    def from_ptr(cls, ptr):
+    def from_mutable_ptr(cls, ptr):
         """Create a new instance from a mutable pointer"""
         new = cls.__new__(cls)
         super(cls, new).__init__(ptr, is_const=False)
@@ -49,12 +49,7 @@ class CxxPointer(object):
         return new
 
     @property
-    def _as_parameter_(self):
-        """used by ctypes when passing self as parameter to a FFI function"""
-        return self.const_ptr
-
-    @property
-    def ptr(self):
+    def mut_ptr(self):
         """Get the **mutable** C++ pointer for this object"""
         if self.__is_const:
             raise ChemfilesError("Trying to use a const pointer for mutable access")
@@ -62,7 +57,7 @@ class CxxPointer(object):
             return self.__ptr
 
     @property
-    def const_ptr(self):
+    def ptr(self):
         """Get the **const** C++ pointer for this object"""
         return self.__ptr
 

--- a/tests/frame.py
+++ b/tests/frame.py
@@ -110,9 +110,6 @@ class TestFrame(unittest.TestCase):
         topology.atoms.append(Atom("Ar"))
 
         frame.topology = topology
-        self.assertEqual(frame.topology.atoms[0].name, "Zn")
-        self.assertEqual(frame.topology.atoms[1].name, "Ar")
-
         self.assertEqual(frame.atoms[0].name, "Zn")
         self.assertEqual(frame.atoms[1].name, "Ar")
 

--- a/tests/property.py
+++ b/tests/property.py
@@ -34,7 +34,8 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(prop.get(), (3, 4, 5))
 
     def test_bad(self):
-        self.assertRaises(ChemfilesError, Property, ArithmeticError)
+        with self.assertRaises(ChemfilesError):
+            _ = Property(ArithmeticError)
 
 
 if __name__ == "__main__":

--- a/tests/trajectory.py
+++ b/tests/trajectory.py
@@ -36,7 +36,7 @@ class TestTrajectory(unittest.TestCase):
             self.assertRaises(ChemfilesError, Trajectory, get_data_path("empty.unknown"))
 
             with Trajectory("test-tmp.xyz", "w") as trajectory:
-                self.assertRaises(ArgumentError, trajectory.write, None)
+                self.assertRaises(AttributeError, trajectory.write, None)
 
             os.unlink("test-tmp.xyz")
 


### PR DESCRIPTION
The first commit fix the code so that the C++ memory is actually freed.

The second one uses the const_ptr/mut_ptr distinction to prevent using `const XXX*` where a `XXX*` is used by the C API.