### PR TITLE
Do not leak file handles and actually close files

### DIFF
--- a/chemfiles/trajectory.py
+++ b/chemfiles/trajectory.py
@@ -41,7 +41,7 @@ class Trajectory(CxxPointer):
             raise ChemfilesError("Can not use a closed Trajectory")
 
     def __del__(self):
-        if not self.__closed and hasattr(self, "__ptr"):
+        if not self.__closed:
             self.close()
 
     def __enter__(self):

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -3,8 +3,12 @@
 set -ex
 
 find . -name "*.pyc" -delete
+find . -name "__pycache__" | xargs rm -rf
 
 rm -rf .tox
 rm -rf _skbuild
 rm -rf dist
 rm -rf chemfiles.egg-info
+rm -rf chemfiles/lib
+rm -rf chemfiles/include
+rm -rf chemfiles/external.py


### PR DESCRIPTION
This is the same issue as 9cbbd5a718d8864bb9cb478df54290613824ade3, only in the `__del__` implementation for Trajectories this time.

Fix #15 